### PR TITLE
BSD-53: Case studies

### DIFF
--- a/config/sync/core.entity_view_display.node.blog.teaser.yml
+++ b/config/sync/core.entity_view_display.node.blog.teaser.yml
@@ -18,10 +18,11 @@ bundle: blog
 mode: teaser
 content:
   field_banner_image:
-    type: entity_reference_label
+    type: entity_reference_entity_view
     label: hidden
     settings:
-      link: true
+      view_mode: default
+      link: false
     third_party_settings: {  }
     weight: 0
     region: content

--- a/stories/components/blurb/blurb-base.html.twig
+++ b/stories/components/blurb/blurb-base.html.twig
@@ -1,0 +1,57 @@
+{#
+/**
+  * Blurb
+  *
+  * Available variables:
+  * - href: String that determines whether to wrap entire content with anchor.
+  * - title: String title.
+  * - description: String content description.
+  * - date: String used in time element.
+  * - in_collection (book, default true): This is one of many blurbs in a collection.
+**/
+#}
+{% if attributes is empty %}
+  {% set attributes = create_attribute() %}
+{% endif %}
+
+{% set blurb_classes = [
+  "bix-blurb",
+] | merge(additional_classes | default([])) %}
+
+{% if in_collection | default(true) %}
+  <li {{ attributes.addClass(blurb_classes) }}>
+{% else %}
+  <div {{ attributes.addClass(blurb_classes) }}>
+{% endif %}
+{{ title_suffix.contextual_links }}
+
+{% set blurb_inner %}
+  <div class="bix-blurb__media">
+    {{ image }}
+  </div>
+  <h3 class="bix-blurb__title">{{ title }}</h3>
+  {% if date %}
+    <time class="bix-blurb__date" datetime="{{ date | date("m-d-Y") }}">
+      {{ date }}
+    </time>
+  {% endif %}
+  {% if description %}
+    <p class="bix-blurb__description">
+      {{ description }}
+    </p>
+  {% endif %}
+{% endset %}
+
+{% if href %}
+  <a href="{{ href | default("javascript:void(0)")}}" class="bix-blurb">
+{% endif %}
+{{ blurb_inner }}
+{% if href %}
+  </a>
+{% endif %}
+
+{% if in_collection | default(true) %}
+  </li>
+{% else %}
+  </div>
+{% endif %}

--- a/stories/components/blurb/blurb-collection-base.html.twig
+++ b/stories/components/blurb/blurb-collection-base.html.twig
@@ -1,0 +1,16 @@
+{% if blurb_collection %}
+  {% if attributes is empty %}
+    {% set attributes = create_attribute() %}
+  {% endif %}
+
+  {% set blurb_classes = [
+    "bix-blurbs",
+    (variant ? "bix-blurbs--" ~ variant | default("two-up")),
+    (featured ? "bix-blurbs--featured"),
+  ] | merge(additional_classes | default([])) %}
+
+  {# @TODO: Support lazy loading after X amount of items. #}
+  <ul {{ attributes.addClass(blurb_classes) }}>
+    {{ blurb_collection }}
+  </ul>
+{% endif %}

--- a/stories/components/blurb/blurb-collection-featured.content.json
+++ b/stories/components/blurb/blurb-collection-featured.content.json
@@ -4,63 +4,63 @@
   "blurbs": [
     {
       "href": "javascript:void(0)",
-      "image": "https://www.bixal.com/static/d6b25ad6c22c438dde0709d18958c405/01c9c/digital-apex-1.webp",
+      "image": "<img src=\"https://www.bixal.com/static/d6b25ad6c22c438dde0709d18958c405/01c9c/digital-apex-1.webp\" alt=\"\">",
       "title": "Building cybersecurity capacity to improve digital health and protect against cyber threats",
       "description": "USAID Digital Apex",
       "date": null
     },
     {
       "href": "javascript:void(0)",
-      "image": "https://www.bixal.com/static/35c60dc21e56c47c5743b9535871e14f/01c9c/fema-image-1.webp",
+      "image": "<img src=\"https://www.bixal.com/static/35c60dc21e56c47c5743b9535871e14f/01c9c/fema-image-1.webp\" alt=\"\">",
       "title": "Educating the public on FEMA's mission",
       "description": null,
       "date": "November 16, 2023"
     },
     {
       "href": "javascript:void(0)",
-      "image": "https://www.bixal.com/static/ef2a68004b3583d87a3d0f91acb22602/f5e99/kdlt-image-1.webp",
+      "image": "<img src=\"https://www.bixal.com/static/ef2a68004b3583d87a3d0f91acb22602/f5e99/kdlt-image-1.webp\" alt=\"\">",
       "title": "Delivering digital communications for food security",
       "description": null,
       "date": "October 26, 2023"
     },
     {
       "href": "javascript:void(0)",
-      "image": "https://www.bixal.com/static/75a99fa13172a7888b09cbfe477ccaa3/3eba8/hhs-careers-hero.webp",
+      "image": "<img src=\"https://www.bixal.com/static/75a99fa13172a7888b09cbfe477ccaa3/3eba8/hhs-careers-hero.webp\" alt=\"\">",
       "title": "Better engagement through human-centered design",
       "description": null,
       "date": "U.S. Department of Health and Human Services"
     },
     {
       "href": "javascript:void(0)",
-      "image": "https://www.bixal.com/static/b0c67b0752535ba810776c24442aa457/f5e99/mel-content-hero.webp",
+      "image": "<img src=\"https://www.bixal.com/static/b0c67b0752535ba810776c24442aa457/f5e99/mel-content-hero.webp\" alt=\"\">",
       "title": "Using data to empower global solutions",
       "description": null,
       "date": "USAID EVAL-ME IDIQ"
     },
     {
       "href": "javascript:void(0)",
-      "image": "https://www.bixal.com/static/1b621cb00e758019369595619fbc6801/f5e99/6-sba.webp",
+      "image": "<img src=\"https://www.bixal.com/static/1b621cb00e758019369595619fbc6801/f5e99/6-sba.webp\" alt=\"\">",
       "title": "Propelling business with multilingual content strategy",
       "description": null,
       "date": "U.S. Small Business Administration"
     },
     {
       "href": "javascript:void(0)",
-      "image": "https://www.bixal.com/static/a78be17224d6f6810f88a30ab62f8921/9c0b3/4-medline-plus.webp",
+      "image": "<img src=\"https://www.bixal.com/static/a78be17224d6f6810f88a30ab62f8921/9c0b3/4-medline-plus.webp\" alt=\"\">",
       "title": "Multilingual marketing expands health services reach",
       "description": null,
       "date": "Medline Plus, Medline Plus en Español"
     },
     {
       "href": "javascript:void(0)",
-      "image": "https://www.bixal.com/static/4df9ced39dacfdf42db05ba23b7141af/9c0b3/1-hud.webp",
+      "image": "<img src=\"https://www.bixal.com/static/4df9ced39dacfdf42db05ba23b7141af/9c0b3/1-hud.webp\" alt=\"\">",
       "title": "Training and certification of housing counselors",
       "description": null,
       "date": "U.S. Department of Housing and Urban Development"
     },
     {
       "href": "javascript:void(0)",
-      "image": "https://www.bixal.com/static/f8d02a773b0855b0cbfafeb3c83c49bb/9c0b3/2-usaid.webp",
+      "image": "<img src=\"https://www.bixal.com/static/f8d02a773b0855b0cbfafeb3c83c49bb/9c0b3/2-usaid.webp\" alt=\"\">",
       "title": "Promoting land tenure and property rights",
       "description": null,
       "date": "U.S. Agency for International Development"

--- a/stories/components/blurb/blurb-collection-featured.content.json
+++ b/stories/components/blurb/blurb-collection-featured.content.json
@@ -1,0 +1,69 @@
+{
+  "variant": "two-up",
+	"featured": true,
+  "blurbs": [
+    {
+      "href": "javascript:void(0)",
+      "image": "https://www.bixal.com/static/d6b25ad6c22c438dde0709d18958c405/01c9c/digital-apex-1.webp",
+      "title": "Building cybersecurity capacity to improve digital health and protect against cyber threats",
+      "description": "USAID Digital Apex",
+      "date": null
+    },
+    {
+      "href": "javascript:void(0)",
+      "image": "https://www.bixal.com/static/35c60dc21e56c47c5743b9535871e14f/01c9c/fema-image-1.webp",
+      "title": "Educating the public on FEMA's mission",
+      "description": null,
+      "date": "November 16, 2023"
+    },
+    {
+      "href": "javascript:void(0)",
+      "image": "https://www.bixal.com/static/ef2a68004b3583d87a3d0f91acb22602/f5e99/kdlt-image-1.webp",
+      "title": "Delivering digital communications for food security",
+      "description": null,
+      "date": "October 26, 2023"
+    },
+    {
+      "href": "javascript:void(0)",
+      "image": "https://www.bixal.com/static/75a99fa13172a7888b09cbfe477ccaa3/3eba8/hhs-careers-hero.webp",
+      "title": "Better engagement through human-centered design",
+      "description": null,
+      "date": "U.S. Department of Health and Human Services"
+    },
+    {
+      "href": "javascript:void(0)",
+      "image": "https://www.bixal.com/static/b0c67b0752535ba810776c24442aa457/f5e99/mel-content-hero.webp",
+      "title": "Using data to empower global solutions",
+      "description": null,
+      "date": "USAID EVAL-ME IDIQ"
+    },
+    {
+      "href": "javascript:void(0)",
+      "image": "https://www.bixal.com/static/1b621cb00e758019369595619fbc6801/f5e99/6-sba.webp",
+      "title": "Propelling business with multilingual content strategy",
+      "description": null,
+      "date": "U.S. Small Business Administration"
+    },
+    {
+      "href": "javascript:void(0)",
+      "image": "https://www.bixal.com/static/a78be17224d6f6810f88a30ab62f8921/9c0b3/4-medline-plus.webp",
+      "title": "Multilingual marketing expands health services reach",
+      "description": null,
+      "date": "Medline Plus, Medline Plus en Español"
+    },
+    {
+      "href": "javascript:void(0)",
+      "image": "https://www.bixal.com/static/4df9ced39dacfdf42db05ba23b7141af/9c0b3/1-hud.webp",
+      "title": "Training and certification of housing counselors",
+      "description": null,
+      "date": "U.S. Department of Housing and Urban Development"
+    },
+    {
+      "href": "javascript:void(0)",
+      "image": "https://www.bixal.com/static/f8d02a773b0855b0cbfafeb3c83c49bb/9c0b3/2-usaid.webp",
+      "title": "Promoting land tenure and property rights",
+      "description": null,
+      "date": "U.S. Agency for International Development"
+    }
+  ]
+}

--- a/stories/components/blurb/blurb-collection.content.json
+++ b/stories/components/blurb/blurb-collection.content.json
@@ -3,49 +3,49 @@
   "blurbs": [
     {
       "href": "javascript:void(0)",
-      "image": "https://www.bixal.com/static/fc63ee09adabef02281c09dcaa8289da/b1ea9/bridging-the-digital-health-divide.webp",
+      "image": "<img src=\"https://www.bixal.com/static/fc63ee09adabef02281c09dcaa8289da/b1ea9/bridging-the-digital-health-divide.webp\" alt=\"\">",
       "title": "Key Learnings for a More Inclusive Global Health Landscape",
       "description": null,
       "date": "November 30, 2023"
     },
     {
       "href": "javascript:void(0)",
-      "image": "https://www.bixal.com/static/2db0d8cfbe6dd9365b1571ff739003f1/b1ea9/drupal-govcon-hero.webp",
+      "image": "<img src=\"https://www.bixal.com/static/2db0d8cfbe6dd9365b1571ff739003f1/b1ea9/drupal-govcon-hero.webp\" alt=\"\">",
       "title": "Insights and Expertise: Bixal’s Impactful Presentations at Drupal GovCon 2023",
       "description": null,
       "date": "November 16, 2023"
     },
     {
       "href": "javascript:void(0)",
-      "image": "https://www.bixal.com/static/325e720386f99923f18635beabdb0e43/b1ea9/human-centered.webp",
+      "image": "<img src=\"https://www.bixal.com/static/325e720386f99923f18635beabdb0e43/b1ea9/human-centered.webp\" alt=\"\">",
       "title": "The Evolving Role of Human-Centered Technology, Key Strategies for Effectively Leveraging the Potential of AI and More: A Q&A With Bixal VP of Technology, Erica Stephens.",
       "description": null,
       "date": "October 26, 2023"
     },
     {
       "href": "javascript:void(0)",
-      "image": "https://www.bixal.com/static/d32b87dd5987b91c37ca03a1ce6895f6/b1ea9/ux-design.webp",
+      "image": "<img src=\"https://www.bixal.com/static/d32b87dd5987b91c37ca03a1ce6895f6/b1ea9/ux-design.webp\" alt=\"\">",
       "title": "Improving UX for Content Managers in Drupal: 5 Practical Tips for Success",
       "description": null,
       "date": "July 19, 2023"
     },
     {
       "href": "javascript:void(0)",
-      "image": "https://www.bixal.com/static/b5d4f2a7af8ad6be49683bc03ec50287/b1ea9/localization.webp",
+      "image": "<img src=\"https://www.bixal.com/static/b5d4f2a7af8ad6be49683bc03ec50287/b1ea9/localization.webp\" alt=\"\">",
       "title": "What Is Localization, Anyway? Four Ways To Put Local People Front and Center in International Development",
       "description": null,
       "date": "May 24, 2022"
     },
     {
       "href": "javascript:void(0)",
-      "image": "https://www.bixal.com/static/1c227651a80c74be058f1ab13939f607/b1ea9/better-cx.webp",
+      "image": "<img src=\"https://www.bixal.com/static/1c227651a80c74be058f1ab13939f607/b1ea9/better-cx.webp\" alt=\"\">",
       "title": "Building Better Customer Experience (CX)",
       "description": null,
       "date": "October 05, 2021"
     },
     {
       "href": "javascript:void(0)",
-      "image": "https://www.bixal.com/static/a5123b8946f0eecdd3112c40721a0f8d/b1ea9/influencing.webp",
+      "image": "<img src=\"https://www.bixal.com/static/a5123b8946f0eecdd3112c40721a0f8d/b1ea9/influencing.webp\" alt=\"\">",
       "title": "Influencing UX Stakeholder Values",
       "description": null,
       "date": "August 10, 2021"

--- a/stories/components/blurb/blurb-collection.html.twig
+++ b/stories/components/blurb/blurb-collection.html.twig
@@ -1,5 +1,7 @@
-<div class="bix-blurbs bix-blurbs--{{ variant | default("two-up") }}">
+<ul class="bix-blurbs bix-blurbs--{{ variant | default("two-up") }}">
   {% for blurb in blurbs %}
-    {% include "@components/blurb/blurb.html.twig" with blurb %}
+    <li>
+      {% include "@components/blurb/blurb.html.twig" with blurb %}
+    </li>
   {% endfor %}
 </div>

--- a/stories/components/blurb/blurb-collection.html.twig
+++ b/stories/components/blurb/blurb-collection.html.twig
@@ -21,8 +21,6 @@
   (additional_classes ? additional_classes),
 ] %}
 
-{# 670px width for Featured collection images #}
-
 {#
 /**
   * Featured collection

--- a/stories/components/blurb/blurb-collection.html.twig
+++ b/stories/components/blurb/blurb-collection.html.twig
@@ -3,40 +3,25 @@
   * Blurb collection
   *
   * Available variables:
-  * - href: String that determines whether to wrap entire content with anchor.
-  * - title: String title.
-  * - description: String content description.
-  * - date: String used in time element.
-**/
-#}
-
-{% if attributes is empty %}
-  {% set attributes = create_attribute() %}
-{% endif %}
-
-{% set blurb_classes = [
-  "bix-blurbs",
-  (variant ? "bix-blurbs--" ~ variant | default("two-up")),
-  (featured ? "bix-blurbs--featured"),
-  (additional_classes ? additional_classes),
-] %}
-
-{#
-/**
-  * Featured collection
+  * - blurbs (array): An array of JSON content used to power blurb.html.twig [href, title, description, date].
+  * - variant (string, default "two-up"):
+  *    - two-up: Always 2 column layout
+  *    - three-up: Auto-fill columns that are minimum of 380px and max of 1fr.
+  * - featured (bool, default false):
+  * - additional_classes (array): Add more classes to the collection wrapper.
   *
-  * Image sizes:
-  *   - Featured:
-  *     - Large: 1350px
-  *     - Small: 516px
-  *   - Regular: 670px
+  * Image size guidance:
+  * - featured is true:
+  *    - First image is: 1350px
+  *    - Rest of images: 516px
+  * - featured is false:
+  *    - All images: 670px
 **/
 #}
-{# @TODO: Support lazy loading after X amount of items. #}
-<ul {{ attributes.addClass(blurb_classes) }}>
+{% extends "@components/blurb/blurb-collection-base.html.twig" %}
+
+{% set blurb_collection %}
   {% for blurb in blurbs %}
-    <li class="bix-blurb">
-      {% include "@components/blurb/blurb.html.twig" with blurb %}
-    </li>
+    {% include "@components/blurb/blurb.html.twig" with blurb %}
   {% endfor %}
-</ul>
+{% endset %}

--- a/stories/components/blurb/blurb-collection.html.twig
+++ b/stories/components/blurb/blurb-collection.html.twig
@@ -1,7 +1,44 @@
-<ul class="bix-blurbs bix-blurbs--{{ variant | default("two-up") }}">
+{#
+/**
+  * Blurb collection
+  *
+  * Available variables:
+  * - href: String that determines whether to wrap entire content with anchor.
+  * - title: String title.
+  * - description: String content description.
+  * - date: String used in time element.
+**/
+#}
+
+{% if attributes is empty %}
+  {% set attributes = create_attribute() %}
+{% endif %}
+
+{% set blurb_classes = [
+  "bix-blurbs",
+  (variant ? "bix-blurbs--" ~ variant | default("two-up")),
+  (featured ? "bix-blurbs--featured"),
+  (additional_classes ? additional_classes),
+] %}
+
+{# 670px width for Featured collection images #}
+
+{#
+/**
+  * Featured collection
+  *
+  * Image sizes:
+  *   - Featured:
+  *     - Large: 1350px
+  *     - Small: 516px
+  *   - Regular: 670px
+**/
+#}
+{# @TODO: Support lazy loading after X amount of items. #}
+<ul {{ attributes.addClass(blurb_classes) }}>
   {% for blurb in blurbs %}
-    <li>
+    <li class="bix-blurb">
       {% include "@components/blurb/blurb.html.twig" with blurb %}
     </li>
   {% endfor %}
-</div>
+</ul>

--- a/stories/components/blurb/blurb.html.twig
+++ b/stories/components/blurb/blurb.html.twig
@@ -1,30 +1,19 @@
-{% set container_element = href ? "a"  : "div" %}
+{#
+/**
+  * Blurb
+  *
+  * Available variables:
+  * - href: String that determines whether to wrap entire content with anchor.
+  * - title: String title.
+  * - description: String content description.
+  * - date: String used in time element.
+  * - in_collection (book, default true): This is one of many blurbs in a collection.
+**/
+#}
+{% extends "@components/blurb/blurb-base.html.twig" %}
 
-{% set blurb_inner %}
-  <div class="bix-blurb__media">
-    <img
-    src="{{ image | default("https://bixal.com/static/ff0d561dd14923cd599238ab42a7745e/4e534/people-first.webp ") }}"
-    alt=""
-    width="750px">
-  </div>
-  <h3 class="bix-blurb__title">{{ title }}</h3>
-  {% if date %}
-  <time class="bix-blurb__date" datetime="{{ date | date("m-d-Y") }}">
-    {{ date }}
-  </time>
-  {% endif %}
-  {% if description %}
-  <p class="bix-blurb__description">
-    {{ description }}
-  </p>
-  {% endif %}
+{% set image %}
+  {% include "@partials/media-image.html.twig" with {
+    'image': image | default('<img src="https://www.bixal.com/static/ff0d561dd14923cd599238ab42a7745e/4e534/people-first.webp" width="750px" alt="">'),
+  } %}
 {% endset %}
-
-
-<{{ container_element }}
-  {% if container_element == "a" %}
-    href="{{ href | default("javascript:void(0)")}}"
-  {% endif %}
-class="bix-blurb">
-  {{ blurb_inner }}
-</{{ container_element }}>

--- a/stories/components/blurb/blurb.scss
+++ b/stories/components/blurb/blurb.scss
@@ -1,8 +1,12 @@
 @use "uswds-core" as *;
 
 .bix-blurbs {
+  list-style: none;
+  margin-top: 0;
+  margin-bottom: 0;
   display: grid;
   gap: units(2);
+  padding-left: 0;
 }
 
 .bix-blurb {

--- a/stories/components/blurb/blurb.scss
+++ b/stories/components/blurb/blurb.scss
@@ -24,16 +24,30 @@
     letter-spacing: 1.25px;
     text-transform: uppercase;
   }
+
+  &__description {
+    margin-top: 0;
+  }
 }
 
 .bix-blurbs--two-up {
   @include at-media("tablet") {
-    grid-template-columns: repeat(auto-fill, minmax(465px, 1fr));
+    grid-template-columns: repeat(2, 1fr);
   }
 }
 
 .bix-blurbs--three-up {
   @include at-media("tablet") {
     grid-template-columns: repeat(auto-fill, minmax(380px, 1fr));
+  }
+}
+
+.bix-blurbs--featured {
+
+  // First child span entire row, ex: Case Studies landing page.
+  & > :first-child {
+    @include at-media("tablet") {
+      grid-column: 1 / -1;
+    }
   }
 }

--- a/stories/components/blurb/blurb.stories.js
+++ b/stories/components/blurb/blurb.stories.js
@@ -1,6 +1,7 @@
 import Blurb from "./blurb.html.twig";
 import BlurbCollectionTemplate from "./blurb-collection.html.twig";
 import BlurbCollectionContent from "./blurb-collection.content.json";
+import BlurbCollectionContentFeatured from "./blurb-collection-featured.content.json";
 
 import "./blurb.scss";
 
@@ -28,5 +29,10 @@ export const BlurbCollectionThreeUp = {
     ...BlurbCollectionContent,
     variant: "three-up",
   },
+  render: BlurbCollectionTemplate,
+};
+
+export const BlurbCollectionFeatured = {
+  args: BlurbCollectionContentFeatured,
   render: BlurbCollectionTemplate,
 };

--- a/stories/components/blurb/blurb.stories.js
+++ b/stories/components/blurb/blurb.stories.js
@@ -16,6 +16,7 @@ export const Default = {
     title: "Key Learnings for a More Inclusive Global Health Landscape",
     description: null,
     date: "November 30, 2023",
+    in_collection: false,
   },
 };
 

--- a/stories/components/button/button.html.twig
+++ b/stories/components/button/button.html.twig
@@ -30,8 +30,7 @@
   "bix-button",
   (variant ? "bix-button--" ~ variant),
   (icon_before ? "bix-button--icon-before"),
-  (additional_classes ? additional_classes),
-] %}
+] | merge(additional_classes | default([])) %}
 
 {% set button_inner %}
   {{ label | default((variant | capitalize | default("Default")) ~ " button")}}

--- a/stories/components/description-list/description-list.html.twig
+++ b/stories/components/description-list/description-list.html.twig
@@ -2,7 +2,7 @@
 
 {% set image %}
   {% include "@partials/media-image.html.twig" with {
-    'image': '<img src="https://www.bixal.com/static/8e16af4c76a75560bbd0719081f3c93b/09633/business-finance.webp" height="155px" alt="">' | default(image),
+    'image': image | default('<img src="https://www.bixal.com/static/8e16af4c76a75560bbd0719081f3c93b/09633/business-finance.webp" height="155px" alt="">'),
     'additional_classes': ['bix-description-list__media']
   } %}
 {% endset %}

--- a/stories/components/section/section.html.twig
+++ b/stories/components/section/section.html.twig
@@ -20,8 +20,7 @@
   (image ? "bix-section--image-bg"),
   (variant ? "bix-section--" ~ variant),
   (center_content ? "bix-section--center-content"),
-  (additional_classes ? additional_classes),
-] %}
+] | merge(additional_classes | default([])) %}
 
 {% set heading_type = heading_type | default("h2") %}
 

--- a/stories/pages/careers/careers.stories.js
+++ b/stories/pages/careers/careers.stories.js
@@ -38,21 +38,21 @@ export const Default = {
       blurbs: [
         {
           image:
-            "https://www.bixal.com/static/d6e70f1bae8881758dd9b06d3fd77607/56d27/careers--thought-leaders.webp",
+            "<img src='https://www.bixal.com/static/d6e70f1bae8881758dd9b06d3fd77607/56d27/careers--thought-leaders.webp'>",
           title: "Thought leaders",
           description:
             "Bixal's team members are constant learners and teachers, supportive of individual and professional growth. We value kindness and humility and seek to build each other up and drive everyone forward.",
         },
         {
           image:
-            "https://www.bixal.com/static/dcaf9d4d8975930ba8811afd2c14d333/95694/careers--collaborative-and-agile.webp",
+            "<img src='https://www.bixal.com/static/dcaf9d4d8975930ba8811afd2c14d333/95694/careers--collaborative-and-agile.webp'>",
           title: "Collaborative & Agile",
           description:
             "We relentlessly focus on outcomes and weave it together with a unique agility that permeates everything we do. Bixal values collaboration and transparency. It shapes how we approach every project.",
         },
         {
           image:
-            "https://www.bixal.com/static/1d156602b6729216b92caa6707ea9ace/56d27/careers--empowered-teams.webp",
+            "<img src='https://www.bixal.com/static/1d156602b6729216b92caa6707ea9ace/56d27/careers--empowered-teams.webp'>",
           title: "Empowered Teams",
           description:
             "Bixal unites different people with different perspectives from all over the world and provides them with an open, empowered environment where creativity can flourish.",

--- a/stories/pages/case-studies-landing/case-studies-landing.html.twig
+++ b/stories/pages/case-studies-landing/case-studies-landing.html.twig
@@ -1,6 +1,5 @@
 {% extends "@pages/base/base.html.twig" %}
 
-
 {% block content %}
   {% include "@components/section/section.html.twig" with intro %}
 
@@ -9,6 +8,4 @@
       {% include "@components/blurb/blurb-collection.html.twig" with blurbs %}
     {% endblock %}
   {% endembed %}
-
-
 {% endblock %}

--- a/stories/pages/case-studies-landing/case-studies-landing.html.twig
+++ b/stories/pages/case-studies-landing/case-studies-landing.html.twig
@@ -4,5 +4,11 @@
 {% block content %}
   {% include "@components/section/section.html.twig" with intro %}
 
-  {% include "@components/blurb/blurb-collection.html.twig" with blurbs %}
+  {% embed "@components/section/section.html.twig" %}
+    {% block body %}
+      {% include "@components/blurb/blurb-collection.html.twig" with blurbs %}
+    {% endblock %}
+  {% endembed %}
+
+
 {% endblock %}

--- a/stories/pages/case-studies-landing/case-studies-landing.html.twig
+++ b/stories/pages/case-studies-landing/case-studies-landing.html.twig
@@ -1,0 +1,8 @@
+{% extends "@pages/base/base.html.twig" %}
+
+
+{% block content %}
+  {% include "@components/section/section.html.twig" with intro %}
+
+  {% include "@components/blurb/blurb-collection.html.twig" with blurbs %}
+{% endblock %}

--- a/stories/pages/case-studies-landing/case-studies-landing.stories.js
+++ b/stories/pages/case-studies-landing/case-studies-landing.stories.js
@@ -1,0 +1,30 @@
+import CaseStudiesLanding from "./case-studies-landing.html.twig";
+
+import * as Header from "../../components/header/header.stories";
+import "../../components/hero/hero.stories";
+import * as Blurb from "../../components/blurb/blurb.stories";
+import "../../components/contact-us/contact-us.stories";
+import "../../components/footer/footer.stories";
+import * as SocialNav from "../../components/social-nav/social-nav.stories";
+
+export default {
+  title: "Pages/Case Studies/Landing",
+  component: CaseStudiesLanding,
+};
+
+export const Default = {
+  args: {
+    header: Header.default.args,
+    hero: {
+      variant: "image-bg",
+      title: "Our Work",
+      image: "https://www.bixal.com/static/0a66c21e57fc6b5c25b6a4b9055bf84f/landing-hero.jpg",
+    },
+    intro: {
+      title: "What we do",
+      description: "<p>At Bixal, we lead human-centered digital transformation and global solutions that drive equity, sustainability and social good. We leverage technology, communications, data and human-centered design to help governments and organizations be more efficient, effective and impactful. Read on to learn more about the broad scope of our work and how we support our clients to provide a better customer experience and, ultimately, improve the lives of the people they serve.</p>",
+    },
+    blurbs: Blurb.BlurbCollection.args,
+    socialNav: SocialNav.default.args
+  },
+};

--- a/stories/pages/case-studies-landing/case-studies-landing.stories.js
+++ b/stories/pages/case-studies-landing/case-studies-landing.stories.js
@@ -24,7 +24,7 @@ export const Default = {
       title: "What we do",
       description: "<p>At Bixal, we lead human-centered digital transformation and global solutions that drive equity, sustainability and social good. We leverage technology, communications, data and human-centered design to help governments and organizations be more efficient, effective and impactful. Read on to learn more about the broad scope of our work and how we support our clients to provide a better customer experience and, ultimately, improve the lives of the people they serve.</p>",
     },
-    blurbs: Blurb.BlurbCollection.args,
+    blurbs: Blurb.BlurbCollectionFeatured.args,
     socialNav: SocialNav.default.args
   },
 };

--- a/stories/pages/case-study/case-study.html.twig
+++ b/stories/pages/case-study/case-study.html.twig
@@ -1,0 +1,126 @@
+{% extends "@pages/base/base.html.twig" %}
+
+{% block content %}
+  {% embed "@components/section/section.html.twig" %}
+    {% block body %}
+
+      <div class="bix-case-study__overview">
+        <dl>
+          <dt>United States Agency for International Development (USAID)</dt>
+          <dd>Digital APEX Colombia</dd>
+          <dd><a href="https://www.usaid.gov/colombia">https://www.usaid.gov/colombia</a></dd>
+        </dl>
+
+        <dl>
+          <dt>Services</dt>
+          <dd>Cybersecurity Training</dd>
+          <dd>Virtual Instructor-led Training</dd>
+          <dd>Capacity Building</dd>
+          <dd>Instructional Design</dd>
+          <dd>Accessibility/508 Compliance</dd>
+          <dd>Bilingual English-Spanish Training Delivery</dd>
+          <dd>Communications</dd>
+          <dd>Marketing</dd>
+          <dd>Cybersecurity Risk Assessments</dd>
+          <dd>Agile Project Management</dd>
+        </dl>
+      </div>
+    {% endblock %}
+  {% endembed %}
+
+  {% embed "@components/section/section.html.twig" %}
+
+    {% block body %}
+      <h2>Challenge</h2>
+      <p>
+        The increased use of technology, mobile phones and digital systems means USAID/Colombia’s IPs face a wide range of vulnerabilities, such as phishing attacks, account impersonation attempts and cyber-based corrupt financial transactions. The scarcity of cybersecurity education for vulnerable IPs translates to a higher risk of attacks and security breaches, which forces organizations to remedy system failures and change user behaviors to mitigate future attacks. Attacks can erode the public’s and stakeholders’ trust in how organizations handle personal and sensitive information, ultimately undermining IPs’ integrity and confidence in the programs they deploy.
+      </p>
+
+      <h2>Solution</h2>
+      <p>
+        Working with the USAID/Colombia Mission, Bixal developed and implemented a cybersecurity training program that used an interactive online training format, assessed existing hardware and software assets, and developed action plans aligned to best practices outlined in the Center for Internet Security (CIS) Controls to improve cybersecurity vulnerabilities.
+      </p>
+
+      <h2>Results</h2>
+      <p>
+        Through a combined approach of asynchronous training and virtual learning, 298 individuals representing 44 organizations in Colombia increased their knowledge of cybersecurity and improved their digital health practices. Bixal conducted cyber risk assessments with the most vulnerable partner organizations to develop roadmaps with action items designed to increase digital protection and reduce the risk of cyberattacks.
+      </p>
+
+      <h2>Design & Approach</h2>
+      <p>
+        Under Digital APEX — implemented by prime contractor Project Management Consulting Group (PMCG) — Bixal collaborated with the USAID/Colombia Mission to develop and implement the Cybersecurity Integration of Partners and Hacking Emergency Response (CIPHER), a cybersecurity training program that uses an easily replicable three-phased approach.
+      </p>
+
+      <h3>Phase 1: Generating Cybersecurity Awareness</h3>
+      <p>
+        Bixal introduced cybersecurity concepts to the participating organizations using KnowBe4, a platform that offers asynchronous training available in Spanish, which enabled the organizations’ leadership, program and IT staff to take self-paced courses and learn more about basic cybersecurity concepts.
+      </p>
+
+      <h3>Phase 2: Assisting Usaid Ips</h3>
+      <p>
+        To deliver additional training and assistance, Bixal identified the 10 most vulnerable IPs based on data from initial training quizzes. We drafted rules of engagement that detailed system restrictions and boundaries to ensure confidentiality throughout the assessment process. Bixal then conducted the cybersecurity risk assessments, testing external and internal accessible systems, hosts and applications for IT, communications and network systems. After completing the assessments, Bixal scheduled individual sessions with each of the 10 IPs, designing virtual instructor-led training (ILT). The in-depth training enabled IT professionals to further diffuse cybersecurity best practices across the organization and ensure all users are aware of their behaviors and responsibility to mitigate cybersecurity attacks and threats.
+      </p>
+
+      <h3>Phase 3: Developing And Disseminating Action Plans</h3>
+      <p>
+        Bixal analyzed data collected through the in-depth training and risk assessments to draft individual action plans for each of the 10 IPs. Action plans communicated assessment results, documented cybersecurity vulnerabilities and provided recommendations for remediation. Bixal and Digital APEX met with IT and management staff of IPs to review action plans and outline steps for IPs to ensure future cybersecurity.
+      </p>
+
+      <h2>Delivering the Solution</h2>
+      <p>
+        Bixal uses proven methods for delivering the right solution to the right client.
+      </p>
+
+      <h3>Collaboration, Learning And Adapting (Cla) Approach</h3>
+      <p>
+        Strong CLA practices enabled Bixal to learn from client feedback and incorporate process improvements to generate better outcomes. The Bixal team met with the client weekly to plan activities, make decisions on preferred approaches for activity implementation, discuss impediments, and identify solutions. This level of client collaboration allowed us to continuously adapt to changing circumstances and stakeholder needs.
+      </p>
+
+      <H3>Local Cybersecurity Expertise</H3>
+      <p>
+        We leveraged a new partnership with Functional Cybersecurity International LLC (FC International), engaging local SMEs with extensive knowledge of cybersecurity threats in Colombia.
+      </p>
+
+      <H3>Data-Centered Methodology</H3>
+      <p>
+        We used data from the cybersecurity training and testing to identify the most vulnerable organizations participating in the program, to inform cybersecurity solutions and topics covered in webinars tailored to selected partners, and to assess the effectiveness of training provided.
+      </p>
+
+      <h2>Unexpected Challenge</h2>
+      <p>
+        As the COVID-19 pandemic worsened and international travel was restricted, Bixal converted our training plan from instructor led to virtual delivery. In-house instructional designers worked with cybersecurity experts to design a highly interactive virtual course that used adult-learning techniques, collaborative whiteboards, short quizzes and pop-up polls to keep participants engaged. As a result of virtual training, 146 participants from 10 IPs experienced a substantial improvement in their cybersecurity knowledge.
+      </p>
+    {% endblock %}
+  {% endembed %}
+
+  {% embed "@components/section/section.html.twig"  %}
+    {% set variant = "primary-alt" %}
+
+    {% block body %}
+      <h2>Outcomes</h2>
+      <p>Bixal applied an Agile learning approach in designing and developing a cybersecurity training program to help USAID IPs and civil society organizations in Colombia improve their digital health, build local capacity and strengthen cybersecurity practices. As part of this program, Bixal provided access to asynchronous training modules and delivered 15 synchronous virtual ILT sessions to over 298 participants from 44 USAID partners. The topics selected contributed to a growing knowledge base on cybersecurity vulnerabilities that impact organizations’ governance structure, technology infrastructure and business operations.</p>
+
+      <p>Working with the USAID/Colombia Mission, Bixal assessed existing hardware and software assets for cybersecurity vulnerabilities and delivered training organized into five learning topics that mapped to 20 CIS controls.</p>
+
+      <p>In Bixal’s experience, when people understand cybersecurity threats and demonstrate familiarity with best practices to combat cyberattacks, the likelihood of destructive cyberattacks decreases.</p>
+
+      <p>Webinar quiz results demonstrated that USAID/Colombia’s IPs had a low baseline knowledge of cybersecurity. Data from the 10 risk assessments conducted in Phase II confirmed the need for cybersecurity action plans. Over 95 percent of participants who identified as “novice” before the training advanced their knowledge to align with higher competency levels as a result of the program. Detailed post-training survey results are captured in the following chart.</p>
+
+      <p>These results demonstrate that a multi-faceted approach, coupling asynchronous and virtual ILT with risk assessments and roadmaps for improvement, can result in significant improvements in cybersecurity awareness.</p>
+    {% endblock %}
+
+
+  {% endembed %}
+
+  {% embed "@components/section/section.html.twig" %}
+    {% block body %}
+
+      <h2>Improvements in recipients’ cybersecurity knowledge after in-depth interactive training.</h2>
+      <p>These results demonstrate that a multi-faceted approach, coupling asynchronous and virtual ILT with risk assessments and roadmaps for improvement, can result in significant improvements in cybersecurity awareness.</p>
+
+      {# @TODO: Highlight component #}
+      <h3>Highlight</h3>
+      <p>Overall, Bixal delivered cybersecurity training to 298 individuals, supporting capacity development for 44 organizations to improve their digital health.</p>
+    {% endblock %}
+  {% endembed %}
+{% endblock %}

--- a/stories/pages/case-study/case-study.stories.js
+++ b/stories/pages/case-study/case-study.stories.js
@@ -1,0 +1,25 @@
+import CaseStudy from "./case-study.html.twig";
+
+import * as Header from "../../components/header/header.stories";
+import "../../components/hero/hero.stories";
+import * as Blurb from "../../components/blurb/blurb.stories";
+import "../../components/contact-us/contact-us.stories";
+import "../../components/footer/footer.stories";
+import * as SocialNav from "../../components/social-nav/social-nav.stories";
+
+export default {
+  title: "Pages/Case Studies/Case Study",
+  component: CaseStudy,
+};
+
+export const Default = {
+  args: {
+    header: Header.default.args,
+    hero: {
+      variant: "image-bg",
+      title: "Building cybersecurity capacity of civil society organizations in Colombia to improve digital health and protect against cyber threats.",
+      image: "https://www.bixal.com/static/d6b25ad6c22c438dde0709d18958c405/digital-apex-1.png",
+    },
+    socialNav: SocialNav.default.args
+  },
+};

--- a/web/themes/custom/bixal_uswds/templates/node/node--blog--teaser.html.twig
+++ b/web/themes/custom/bixal_uswds/templates/node/node--blog--teaser.html.twig
@@ -66,7 +66,6 @@
  * @see template_preprocess_node()
  */
 #}
-
 {%
   set classes = [
   'node',
@@ -78,12 +77,10 @@
 ]
 %}
 
-<article{{ attributes.addClass(classes) }}>
-  {% include "@components/blurb/blurb.html.twig" with {
+{% include "@components/blurb/blurb-base.html.twig" with {
   'title': node.label,
-  'image' : file_url(content.field_banner_image['#object'].field_banner_image.entity.field_media_image.entity.uri.getString()),
+  'image' : content.field_banner_image | field_value,
   'date': content.field_date.0['#text'],
-  'href': path('entity.node.canonical', {'node': node.id})
-
+  'href': path('entity.node.canonical', {'node': node.id}),
+  'additional_classes': classes,
 } %}
-</article>

--- a/web/themes/custom/bixal_uswds/templates/paragraphs/paragraph--blurb-collection.html.twig
+++ b/web/themes/custom/bixal_uswds/templates/paragraphs/paragraph--blurb-collection.html.twig
@@ -38,19 +38,18 @@
  * @ingroup themeable
  */
 #}
-{% set classes = [
-  'component',
-  'bix-blurbs',
-  'bix-blurbs--' ~ content.field_blurb_collection_variant['#items'].getString(),
-  'component--type--' ~ paragraph.bundle|clean_class,
-  view_mode ?  'component--view-mode--' ~ view_mode|clean_class,
-  not paragraph.isPublished() ?  'component--unpublished'
-] %}
-
+{# @todo: Add a field to blurb collection that is a boolean for 'featured', it is an option to blurb-collection-base
+  and makes the first blurb full width.
+#}
 {% block paragraph %}
-  <div{{attributes.addClass(classes)}}>
-    {% block content %}
-      {{ content.field_blurbs |field_value }}
-    {% endblock %}
-  </div>
+  {% include '@components/blurb/blurb-collection-base.html.twig' with {
+    'blurb_collection': content.field_blurbs | field_value,
+    'variant': content.field_blurb_collection_variant['#items'].getString(),
+    'additional_classes': [
+      'component',
+      'component--type--' ~ paragraph.bundle|clean_class,
+      view_mode ?  'component--view-mode--' ~ view_mode|clean_class,
+      not paragraph.isPublished() ?  'component--unpublished'
+    ],
+  }%}
 {% endblock paragraph %}

--- a/web/themes/custom/bixal_uswds/templates/paragraphs/paragraph--blurb.html.twig
+++ b/web/themes/custom/bixal_uswds/templates/paragraphs/paragraph--blurb.html.twig
@@ -40,13 +40,16 @@
 #}
 
 {% block paragraph %}
-  <div{{attributes.addClass(classes)}}>
-    {% include '@components/blurb/blurb.html.twig' with {
-      'title': content.field_title | field_value,
-      'image': file_url(content.field_image['#object'].field_image.entity.field_media_image.entity.uri.getString()),
-      'description': content.field_description | field_value,
-      'date': content.field_date.0['#text'],
-    }
-    %}
-  </div>
+  {% include '@components/blurb/blurb-base.html.twig' with {
+    'title': content.field_title | field_value,
+    'image': content.field_image | field_value,
+    'description': content.field_description | field_value,
+    'date': content.field_date.0['#text'],
+    'additional_classes': [
+      'component',
+      'component--type--' ~ paragraph.bundle|clean_class,
+      view_mode ?  'component--view-mode--' ~ view_mode|clean_class,
+      not paragraph.isPublished() ?  'component--unpublished'
+    ],
+  } %}
 {% endblock %}

--- a/web/themes/custom/bixal_uswds/templates/views/views-view--blog.html.twig
+++ b/web/themes/custom/bixal_uswds/templates/views/views-view--blog.html.twig
@@ -64,9 +64,10 @@
       {% endif %}
 
       {% if rows %}
-        <div class="bix-blurbs bix-blurbs--two-up">
-          {{ rows }}
-        </div>
+        {% include '@components/blurb/blurb-collection-base.html.twig' with {
+          'blurb_collection': rows,
+          'variant': 'two-up',
+        } %}
       {% elseif empty %}
         <div class="view-empty">
           {{ empty }}


### PR DESCRIPTION
Created Case Study landing page and placeholder case study. Closes #53.

## Major changes

### Blurb component

1. New variant called `Blurb Collection Featured`.
2. Blurbs are now in an unordered list, instead of a `div`.

**Blurb featured**

Some of the images are slightly larger — _ex: Educating the public vs  Delivering Digital Communications for Food Security._ On live there's a fixed height and styles to make them all the same. We should **avoid** this pattern and set consistent images by default to avoid warping and/or blurriness on small screens.

![image](https://github.com/Bixal/bixal-site-drupal/assets/3385219/6e92b69d-324a-4c56-9553-7324e9b08a3c)

The first item will always be full width.

### Responsive images

Image sizes below are suggested for this component.

**Featured**
Large: 1350px
Small: 516px

**Regular** 
670px