### PR TITLE
Fixes #77: Description list missing vertical line when logged in

### DIFF
--- a/stories/assets/styles/global/global.scss
+++ b/stories/assets/styles/global/global.scss
@@ -170,6 +170,11 @@ img {
   vertical-align: middle; // Remove extra space from images.
 }
 
+figure {
+  margin: 0;
+  padding: 0;
+}
+
 address {
   font-style: normal;
 }

--- a/stories/components/description-list/description-list-base.html.twig
+++ b/stories/components/description-list/description-list-base.html.twig
@@ -1,9 +1,14 @@
-<dl class="bix-description-list bix-description-list--{{ variant }}">
-  {% if image %}
-    <div class="bix-description-list__media">
-      {{ image }}
-    </div>
-  {% endif %}
+{% if attributes is empty %}
+  {% set attributes = create_attribute() %}
+{% endif %}
+
+{% set classes = [
+  'bix-description-list',
+  'bix-description-list--' ~ variant | clean_class,
+] %}
+
+<dl{{ attributes.addClass(classes).addClass(additional_classes) }}>
+  {{ image }}
   {% if title %}
     <dt class="bix-description-list__heading">
       {{ title }}

--- a/stories/components/description-list/description-list-collection-base.html.twig
+++ b/stories/components/description-list/description-list-collection-base.html.twig
@@ -1,0 +1,7 @@
+{% if attributes is empty %}
+  {% set attributes = create_attribute() %}
+{% endif %}
+
+<div{{ attributes.addClass('bix-description-list-collection').addClass(additional_classes) }}>
+  {{ description_list_collection }}
+</div>

--- a/stories/components/description-list/description-list-collection.html.twig
+++ b/stories/components/description-list/description-list-collection.html.twig
@@ -1,5 +1,7 @@
-<div class="bix-description-list-collection">
+{% extends "@components/description-list/description-list-collection-base.html.twig" %}
+
+{% set description_list_collection %}
   {% for description in collections %}
     {% include "@components/description-list/description-list.html.twig" with description %}
   {% endfor %}
-</div>
+{% endset %}

--- a/stories/components/description-list/description-list.html.twig
+++ b/stories/components/description-list/description-list.html.twig
@@ -1,10 +1,11 @@
 {% extends "@components/description-list/description-list-base.html.twig" %}
 
-{% if image is empty %}
-  {% set image %}
-    <img src="https://www.bixal.com/static/8e16af4c76a75560bbd0719081f3c93b/09633/business-finance.webp" height="155px" alt="">
-  {% endset %}
-{% endif %}
+{% set image %}
+  {% include "@partials/media-image.html.twig" with {
+    'image': '<img src="https://www.bixal.com/static/8e16af4c76a75560bbd0719081f3c93b/09633/business-finance.webp" height="155px" alt="">' | default(image),
+    'additional_classes': ['bix-description-list__media']
+  } %}
+{% endset %}
 
 {% if title is empty %}
   {% set title = 'Health' %}

--- a/stories/partials/media-image.html.twig
+++ b/stories/partials/media-image.html.twig
@@ -1,0 +1,13 @@
+{% if attributes is empty %}
+  {% set attributes = create_attribute() %}
+{% endif %}
+
+<figure{{ attributes.addClass(additional_classes) }}>
+  {{ image }}
+  {% if caption %}
+    <figcaption>
+      {{ caption }}
+    </figcaption>
+  {% endif %}
+  {{ contextual_links }}
+</figure>

--- a/vite.config.js
+++ b/vite.config.js
@@ -15,6 +15,7 @@ export default defineConfig({
       namespaces: {
         components: join(__dirname, "./stories/components"),
         pages: join(__dirname, "./stories/pages"),
+        partials: join(__dirname, "./stories/partials"),
       },
     }),
   ],

--- a/web/themes/custom/bixal_uswds/bixal_uswds.info.yml
+++ b/web/themes/custom/bixal_uswds/bixal_uswds.info.yml
@@ -13,6 +13,7 @@ components:
   namespaces:
     pages: storybook_components/stories/pages
     components: storybook_components/stories/components
+    partials: storybook_components/stories/partials
 
 libraries:
   - bixal_uswds/global

--- a/web/themes/custom/bixal_uswds/templates/media/media--image--description-list.html.twig
+++ b/web/themes/custom/bixal_uswds/templates/media/media--image--description-list.html.twig
@@ -1,0 +1,20 @@
+{#
+/**
+ * @file
+ * Theme override to display a media item.
+ *
+ * Available variables:
+ * - media: The media item, with limited access to object properties and
+ *   methods.
+ * - name: Name of the media.
+ * - content: Media content.
+ *
+ * @see template_preprocess_media()
+ *
+ * @ingroup themeable
+ */
+#}
+
+{% include "media--image.html.twig" with {
+  additional_classes: ['bix-description-list__media']
+}%}

--- a/web/themes/custom/bixal_uswds/templates/media/media--image.html.twig
+++ b/web/themes/custom/bixal_uswds/templates/media/media--image.html.twig
@@ -15,25 +15,18 @@
  */
 #}
 
-{% set classes = [
+{% set additional_classes = [
   'media-image',
   'media',
   'media--type-' ~ media.bundle()|clean_class,
   not media.isPublished() ? 'media--unpublished',
   view_mode ? 'media--view-mode-' ~ view_mode|clean_class,
-] %}
+] | merge(additional_classes | default([]))
+%}
 
-<figure{{ attributes.addClass(classes) }}>
-  {{ title_suffix.contextual_links }}
-
-  {% if content.field_media_image | render %}
-    {{ content.field_media_image | field_value }}
-  {% endif %}
-
-  {% if content.field_image_caption | render %}
-    <figcaption>
-      {{ content.field_image_caption | field_value }}
-    </figcaption>
-  {% endif %}
-</figure>
-
+{% include "@partials/media-image.html.twig" with {
+  'image': content.field_media_image | field_value,
+  'caption': content.field_image_caption | field_value,
+  'contextual_links': title_suffix.contextual_links,
+  'additional_classes': additional_classes,
+} %}

--- a/web/themes/custom/bixal_uswds/templates/paragraphs/paragraph--description-list-collection.html.twig
+++ b/web/themes/custom/bixal_uswds/templates/paragraphs/paragraph--description-list-collection.html.twig
@@ -38,18 +38,18 @@
  * @ingroup themeable
  */
 #}
-{% set classes = [
+
+{% set additional_classes = [
   'component',
-  'bix-description-list-collection',
   'component--type--' ~ paragraph.bundle|clean_class,
   view_mode ?  'component--view-mode--' ~ view_mode|clean_class,
-  not paragraph.isPublished() ?  'component--unpublished'
-] %}
+  not paragraph.isPublished() ?  'component--unpublished',
+] | merge(additional_classes | default([]))
+%}
 
 {% block paragraph %}
-  <div{{attributes.addClass(classes)}}>
-    {% block content %}
-      {{ content.field_description_lists |field_value }}
-    {% endblock %}
-  </div>
+  {% include '@components/description-list/description-list-collection-base.html.twig' with {
+    'description_list_collection': content.field_description_lists | field_value,
+    'additional_classes': additional_classes,
+  } %}
 {% endblock paragraph %}

--- a/web/themes/custom/bixal_uswds/templates/paragraphs/paragraph--description-list.html.twig
+++ b/web/themes/custom/bixal_uswds/templates/paragraphs/paragraph--description-list.html.twig
@@ -39,14 +39,20 @@
  */
 #}
 
+{% set additional_classes = [
+  'component',
+  'component--type--' ~ paragraph.bundle|clean_class,
+  view_mode ?  'component--view-mode--' ~ view_mode|clean_class,
+  not paragraph.isPublished() ?  'component--unpublished',
+] | merge(additional_classes | default([]))
+%}
+
 {% block paragraph %}
-  <div{{ attributes.addClass(classes) }}>
-    {% include '@components/description-list/description-list-base.html.twig' with {
-      'title': content.field_title | field_value,
-      'image': content.field_image.0,
-      'items': content.field_description_list_items,
-      'variant': content.field_description_list_variant['#items'].getString()
-      
-    } %}
-  </div>
+  {% include '@components/description-list/description-list-base.html.twig' with {
+    'title': content.field_title | field_value,
+    'image': content.field_image.0,
+    'items': content.field_description_list_items,
+    'variant': content.field_description_list_variant['#items'].getString(),
+    'additional_classes': additional_classes,
+  } %}
 {% endblock paragraph %}


### PR DESCRIPTION
I'm kind of torn on the implementation here, because it took some extra scaffolding but I think it's pretty clean.
Instead of adding an extra wrapper around the description list image, I merged the 2 elements. This was required because the outer one added a position relative (for the vertical line) and the inner one (in Drupal) added contextual region class (for Drupal contextual edit links) which also added a position relative. Since they were nested position relatives, the outer one did not work (the vertical line). Now the vertical line class and contextual region class are in the same wrapper (a <figure> in this case).

Also, I've re-implemented description list collection so it can easily be used in Drupal. Basic gist is that:
* SB components should extend a 'base' template.
* The components should use 'set var' for any dynamic content
* The 'base' templates will use those 'set vars'.
* SB will use the component
* Drupal will use only the base component, Drupal will use it's templates (like paragraph templates) to set the vars instead of the SB components.

I've also added another paradigm where components that require a wrapper should be implemented like:
```
{% if attributes is empty %}
  {% set attributes = create_attribute() %}
{% endif %}

{% set classes = [
  'bix-description-list',
  'bix-description-list--' ~ variant | clean_class,
] %}

<dl{{ attributes.addClass(classes).addClass(additional_classes) }}>
```
In this way:
* both SB and Drupal can take advantage of the `attributes` var that Drupal already uses
* SB will define classes that will always wrap a component, then both SB or Drupal can pass the var `additional_classes` to add more to a wrapper.

Why would Drupal need to add it's own attributes? Because of the extra functionality in Drupal, like contextual edit links. This will allow them to automatically flow into the wrappers of components when they hit Drupal.