### PR TITLE
BSD closes #99: Preprocess to hit lever api and feed to job listing p…

### DIFF
--- a/config/sync/paragraphs.paragraphs_type.job_listing.yml
+++ b/config/sync/paragraphs.paragraphs_type.job_listing.yml
@@ -1,0 +1,10 @@
+uuid: df6eb835-f8d1-4715-88d1-7edf97975617
+langcode: en
+status: true
+dependencies: {  }
+id: job_listing
+label: 'Job Listing'
+icon_uuid: null
+icon_default: null
+description: ''
+behavior_plugins: {  }

--- a/web/modules/custom/bixal_default_content/content/node/24fbd4e2-27b4-4cb1-b3c6-264a33426868.yml
+++ b/web/modules/custom/bixal_default_content/content/node/24fbd4e2-27b4-4cb1-b3c6-264a33426868.yml
@@ -387,15 +387,15 @@ default:
                       options: {  }
           field_center_content:
             -
-              value: false
+              value: true
           field_nested_paragraphs:
             -
               entity:
                 _meta:
                   version: '1.0'
                   entity_type: paragraph
-                  uuid: f2d74741-4a8f-48c0-acbf-83e5240ec067
-                  bundle: emphasis_block_collection
+                  uuid: 5653c68e-a390-4ec8-945f-0b9e302d5623
+                  bundle: job_listing
                   default_langcode: en
                 default:
                   status:
@@ -403,124 +403,10 @@ default:
                       value: true
                   created:
                     -
-                      value: 1706797711
+                      value: 1710177074
                   behavior_settings:
                     -
                       value: {  }
-                  field_emphasis_blocks:
-                    -
-                      entity:
-                        _meta:
-                          version: '1.0'
-                          entity_type: paragraph
-                          uuid: bc8ed2b9-756b-43b9-81fb-3f3af0eb9c92
-                          bundle: emphasis_block
-                          default_langcode: en
-                        default:
-                          status:
-                            -
-                              value: true
-                          created:
-                            -
-                              value: 1706797711
-                          behavior_settings:
-                            -
-                              value: {  }
-                          field_link:
-                            -
-                              uri: 'https://jobs.lever.co/bixal/6ec40093-636e-45cc-8274-11c68960b211'
-                              title: 'Events & Partnerships Strategist'
-                              options: {  }
-                          field_postfix_text:
-                            -
-                              value: 'Washington D.C. Metro Area'
-                          field_prefix_title:
-                            -
-                              value: 'CORPORATE MARKETING & ENGAGEMENT'
-                    -
-                      entity:
-                        _meta:
-                          version: '1.0'
-                          entity_type: paragraph
-                          uuid: eb7265eb-8473-4624-a8ab-088b75ecff4a
-                          bundle: emphasis_block
-                          default_langcode: en
-                        default:
-                          status:
-                            -
-                              value: true
-                          created:
-                            -
-                              value: 1706797746
-                          behavior_settings:
-                            -
-                              value: {  }
-                          field_link:
-                            -
-                              uri: 'https://jobs.lever.co/bixal/743c2cbb-478e-40b8-9eda-cb65deeeae39'
-                              title: 'MEL Program Associate'
-                              options: {  }
-                          field_postfix_text:
-                            -
-                              value: 'Washington D.C. Metro Area'
-                          field_prefix_title:
-                            -
-                              value: MEL
-                    -
-                      entity:
-                        _meta:
-                          version: '1.0'
-                          entity_type: paragraph
-                          uuid: 9cfa3ddf-5de3-47e4-9bba-4a6dfea037c4
-                          bundle: emphasis_block
-                          default_langcode: en
-                        default:
-                          status:
-                            -
-                              value: true
-                          created:
-                            -
-                              value: 1706797792
-                          behavior_settings:
-                            -
-                              value: {  }
-                          field_link:
-                            -
-                              uri: 'https://jobs.lever.co/bixal/10d13e00-2dcd-4315-bbdb-85cdf57abfae'
-                              title: 'Sr. Project Manager'
-                              options: {  }
-                          field_prefix_title:
-                            -
-                              value: 'PROJECT MANAGEMENT'
-                    -
-                      entity:
-                        _meta:
-                          version: '1.0'
-                          entity_type: paragraph
-                          uuid: 0741bda1-f904-44f8-b742-cdacae052a22
-                          bundle: emphasis_block
-                          default_langcode: en
-                        default:
-                          status:
-                            -
-                              value: true
-                          created:
-                            -
-                              value: 1706797830
-                          behavior_settings:
-                            -
-                              value: {  }
-                          field_link:
-                            -
-                              uri: 'https://jobs.lever.co/bixal/684d5c9d-5a67-4f68-99ef-baac8ba2ba81'
-                              title: 'General Opportunities'
-                              options: {  }
-                          field_postfix_text:
-                            -
-                              value: 'Washington D.C. Metro Area'
-                          field_prefix_title:
-                            -
-                              value: OTHER
           field_title:
             -
               value: 'Featured Jobs'

--- a/web/themes/custom/bixal_uswds/php-includes/paragraphs.inc
+++ b/web/themes/custom/bixal_uswds/php-includes/paragraphs.inc
@@ -7,6 +7,8 @@
 
 use Drupal\node\Entity\Node;
 use Drupal\taxonomy\Entity\Term;
+use GuzzleHttp\Client;
+use GuzzleHttp\Exception\RequestException;
 
 /**
  * Implements hook_preprocess_paragraph().
@@ -134,7 +136,7 @@ function bixal_uswds_preprocess_paragraph(&$vars) {
           // Add team to array if it doesn't exist in array.
           if (!in_array($team_name, $filter_options)) {
             $filter_options[] = $team_name;
-          };
+          }
         }
 
         // Sort filter options.
@@ -145,6 +147,59 @@ function bixal_uswds_preprocess_paragraph(&$vars) {
           'filter_content' => $filter_content,
           'filter_options' => $filter_options,
         ];
+
+        break;
+
+      case "job_listing":
+        // Create jobs array, teams array, and client object.
+        $client = new Client();
+        $jobs = [];
+        $teams = [
+          'Corporate Operations',
+          'Data Analytics',
+          'Human Centered Design',
+          'International',
+          'Learning',
+          'Program Management',
+          'Technology',
+          'Other Teams',
+        ];
+
+        // Try to read from API.
+        try {
+          foreach ($teams as $team) {
+            $query_string = rawurlencode($team);
+            $response = $client->get("https://api.lever.co/v0/postings/bixal?department={$query_string}");
+            $result = json_decode($response->getBody(), TRUE);
+            $listings[$team] = $result;
+
+            // Sort listing based on most recent.
+            usort($listings[$team], function ($job1, $job2) {
+              return $job2['createdAt'] <=> $job1['createdAt'];
+            });
+
+            // Remove all but most recent.
+            array_splice($listings[$team], 1);
+
+            // If team index of listings array isn't empty, set for jobs array.
+            if (!empty($listings[$team])) {
+              $jobs[] = [
+                'title' => $listings[$team][0]['text'],
+                'href' => $listings[$team][0]['hostedUrl'],
+                'prefix' => $listings[$team][0]['categories']['team'],
+                'postfix' => $listings[$team][0]['categories']['location'],
+              ];
+            }
+          }
+
+          // Set content to jobs.
+          $vars['content'] = [
+            'jobs' => $jobs,
+          ];
+        }
+        catch (RequestException $e) {
+          \Drupal::logger('system')->alert('Jobs could not be fetched from lever.');
+        }
 
         break;
 

--- a/web/themes/custom/bixal_uswds/php-includes/paragraphs.inc
+++ b/web/themes/custom/bixal_uswds/php-includes/paragraphs.inc
@@ -168,8 +168,7 @@ function bixal_uswds_preprocess_paragraph(&$vars) {
         // Try to read from API.
         try {
           foreach ($teams as $team) {
-            $query_string = rawurlencode($team);
-            $response = $client->get("https://api.lever.co/v0/postings/bixal?department={$query_string}");
+            $response = $client->get("https://api.lever.co/v0/postings/bixal", ['query' => ['department' => $team]]);
             $result = json_decode($response->getBody(), TRUE);
             $listings[$team] = $result;
 

--- a/web/themes/custom/bixal_uswds/templates/paragraphs/paragraph--job-listing.html.twig
+++ b/web/themes/custom/bixal_uswds/templates/paragraphs/paragraph--job-listing.html.twig
@@ -1,0 +1,52 @@
+{#
+/**
+ * @file
+ * Default theme implementation to display a paragraph.
+ *
+ * Available variables:
+ * - paragraph: Full paragraph entity.
+ *   Only method names starting with "get", "has", or "is" and a few common
+ *   methods such as "id", "label", and "bundle" are available. For example:
+ *   - paragraph.getCreatedTime() will return the paragraph creation timestamp.
+ *   - paragraph.id(): The paragraph ID.
+ *   - paragraph.bundle(): The type of the paragraph, for example, "image" or "text".
+ *   - paragraph.getOwnerId(): The user ID of the paragraph author.
+ *   See Drupal\paragraphs\Entity\Paragraph for a full list of public properties
+ *   and methods for the paragraph object.
+ * - content: All paragraph items. Use {{ content }} to print them all,
+ *   or print a subset such as {{ content.field_example }}. Use
+ *   {{ content|without('field_example') }} to temporarily suppress the printing
+ *   of a given child element.
+ * - attributes: HTML attributes for the containing element.
+ *   The attributes.class element may contain one or more of the following
+ *   classes:
+ *   - paragraphs: The current template type (also known as a "theming hook").
+ *   - paragraphs--type-[type]: The current paragraphs type. For example, if the paragraph is an
+ *     "Image" it would result in "paragraphs--type--image". Note that the machine
+ *     name will often be in a short form of the human readable label.
+ *   - paragraphs--view-mode--[view_mode]: The View Mode of the paragraph; for example, a
+ *     preview would result in: "paragraphs--view-mode--preview", and
+ *     default: "paragraphs--view-mode--default".
+ * - view_mode: View mode; for example, "preview" or "full".
+ * - logged_in: Flag for authenticated user status. Will be true when the
+ *   current user is a logged-in member.
+ * - is_admin: Flag for admin user status. Will be true when the current user
+ *   is an administrator.
+ *
+ * @see template_preprocess_paragraph()
+ *
+ * @ingroup themeable
+ */
+#}
+{% set classes = [
+  'component',
+  'component--type--' ~ paragraph.bundle|clean_class,
+  view_mode ?  'component--view-mode--' ~ view_mode|clean_class,
+  not paragraph.isPublished() ?  'component--unpublished'
+] %}
+
+{% block paragraph %}
+  {% include '@components/emphasis-block/emphasis-block-collection.html.twig' with {
+      'blocks': content.jobs,
+    } %}
+{% endblock paragraph %}


### PR DESCRIPTION
# Job Listings on Career Page

- Created job listing paragraph
- preprocessed paragraph to hit API endpoint per team
- sorted returned array to get latest
- saved most recent to jobs array
- passed jobs array to twig template, that extends emphasis block collection