### PR TITLE
BSD closes #103: Install and configure chosen for taxonomy ref fields

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,6 +22,7 @@
         "composer/installers": "^2.0",
         "cweagans/composer-patches": "^1.7",
         "drupal/admin_toolbar": "^3.4",
+        "drupal/chosen": "^4.0",
         "drupal/components": "^3.0@beta",
         "drupal/core-composer-scaffold": "^10.1",
         "drupal/core-project-message": "^10.1",

--- a/composer.json
+++ b/composer.json
@@ -14,6 +14,21 @@
             "url": "https://packages.drupal.org/8"
         },
         {
+            "type": "package",
+            "package": {
+                "name": "jjj/chosen",
+                "version": "2.2.1",
+                "type": "drupal-library",
+                "extra": {
+                    "installer-name": "chosen"
+                },
+                "dist": {
+                    "url": "https://github.com/JJJ/chosen/archive/refs/tags/2.2.1.zip",
+                    "type": "zip"
+                }
+            }
+        },
+        {
             "type": "vcs",
             "url": "git@github.com:mpbixal/drupal-platform-lando.git"
         }
@@ -46,6 +61,7 @@
         "drupal/twig_tweak": "^3.2",
         "drupal/xmlsitemap": "^1.5",
         "drush/drush": "*",
+        "jjj/chosen": "2.2.1",
         "mattsqd/robovalidate": "@alpha",
         "mpbixal/drupal-platform-lando": "dev-main",
         "platformsh/config-reader": "^2.4"

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "adc80e7ac000a2865042eeca698894fe",
+    "content-hash": "a80ed547defd903ddbe193901a0a8309",
     "packages": [
         {
             "name": "asm89/stack-cors",
@@ -4254,6 +4254,18 @@
                 }
             ],
             "time": "2023-11-28T21:12:40+00:00"
+        },
+        {
+            "name": "jjj/chosen",
+            "version": "2.2.1",
+            "dist": {
+                "type": "zip",
+                "url": "https://github.com/JJJ/chosen/archive/refs/tags/2.2.1.zip"
+            },
+            "type": "drupal-library",
+            "extra": {
+                "installer-name": "chosen"
+            }
         },
         {
             "name": "laminas/laminas-stdlib",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "2be1c68fe52de17ed2fe781a85da083a",
+    "content-hash": "adc80e7ac000a2865042eeca698894fe",
     "packages": [
         {
             "name": "asm89/stack-cors",
@@ -1547,6 +1547,155 @@
             "support": {
                 "source": "https://git.drupalcode.org/project/admin_toolbar",
                 "issues": "https://www.drupal.org/project/issues/admin_toolbar"
+            }
+        },
+        {
+            "name": "drupal/chosen",
+            "version": "4.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://git.drupalcode.org/project/chosen.git",
+                "reference": "4.0.0"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://ftp.drupal.org/files/projects/chosen-4.0.0.zip",
+                "reference": "4.0.0",
+                "shasum": "6355b49a1dc90f372d38b0e100745e387cad3423"
+            },
+            "require": {
+                "drupal/chosen_lib": "*",
+                "drupal/core": "^9.2 || ^10"
+            },
+            "type": "drupal-module",
+            "extra": {
+                "drupal": {
+                    "version": "4.0.0",
+                    "datestamp": "1680955162",
+                    "security-coverage": {
+                        "status": "covered",
+                        "message": "Covered by Drupal's security advisory policy"
+                    }
+                }
+            },
+            "notification-url": "https://packages.drupal.org/8/downloads",
+            "license": [
+                "GPL-2.0-or-later"
+            ],
+            "authors": [
+                {
+                    "name": "aidanlis",
+                    "homepage": "https://www.drupal.org/user/502018"
+                },
+                {
+                    "name": "Cyclodex",
+                    "homepage": "https://www.drupal.org/user/1305230"
+                },
+                {
+                    "name": "Dave Reid",
+                    "homepage": "https://www.drupal.org/user/53892"
+                },
+                {
+                    "name": "Hydra",
+                    "homepage": "https://www.drupal.org/user/647364"
+                },
+                {
+                    "name": "kalman.hosszu",
+                    "homepage": "https://www.drupal.org/user/267481"
+                },
+                {
+                    "name": "nagy.balint",
+                    "homepage": "https://www.drupal.org/user/1763952"
+                },
+                {
+                    "name": "Pol",
+                    "homepage": "https://www.drupal.org/user/47194"
+                },
+                {
+                    "name": "shadcn",
+                    "homepage": "https://www.drupal.org/user/571032"
+                },
+                {
+                    "name": "supercabbageuk",
+                    "homepage": "https://www.drupal.org/user/235438"
+                }
+            ],
+            "description": "Makes select elements more user-friendly using <a href=\"https://github.com/JJJ/chosen\">Chosen</a>.",
+            "homepage": "https://www.drupal.org/project/chosen",
+            "support": {
+                "source": "https://git.drupalcode.org/project/chosen"
+            }
+        },
+        {
+            "name": "drupal/chosen_lib",
+            "version": "4.0.0",
+            "require": {
+                "drupal/chosen": "^4",
+                "drupal/core": "^9.2 || ^10",
+                "php": ">=5.6.0"
+            },
+            "type": "metapackage",
+            "extra": {
+                "drupal": {
+                    "version": "4.0.0",
+                    "datestamp": "1680955162",
+                    "security-coverage": {
+                        "status": "covered",
+                        "message": "Covered by Drupal's security advisory policy"
+                    }
+                },
+                "drush": {
+                    "services": {
+                        "drush.services.yml": "^9 || ^10 || ^11"
+                    }
+                }
+            },
+            "notification-url": "https://packages.drupal.org/8/downloads",
+            "license": [
+                "GPL-2.0-or-later"
+            ],
+            "authors": [
+                {
+                    "name": "aidanlis",
+                    "homepage": "https://www.drupal.org/user/502018"
+                },
+                {
+                    "name": "Cyclodex",
+                    "homepage": "https://www.drupal.org/user/1305230"
+                },
+                {
+                    "name": "Dave Reid",
+                    "homepage": "https://www.drupal.org/user/53892"
+                },
+                {
+                    "name": "Hydra",
+                    "homepage": "https://www.drupal.org/user/647364"
+                },
+                {
+                    "name": "kalman.hosszu",
+                    "homepage": "https://www.drupal.org/user/267481"
+                },
+                {
+                    "name": "nagy.balint",
+                    "homepage": "https://www.drupal.org/user/1763952"
+                },
+                {
+                    "name": "Pol",
+                    "homepage": "https://www.drupal.org/user/47194"
+                },
+                {
+                    "name": "shadcn",
+                    "homepage": "https://www.drupal.org/user/571032"
+                },
+                {
+                    "name": "supercabbageuk",
+                    "homepage": "https://www.drupal.org/user/235438"
+                }
+            ],
+            "description": "This module provides the basic integration with the Chosen jQuery plugin.",
+            "homepage": "https://www.drupal.org/project/chosen",
+            "support": {
+                "source": "https://git.drupalcode.org/project/chosen"
             }
         },
         {

--- a/composer.log
+++ b/composer.log
@@ -6,3 +6,4 @@ a42621d48ea57cbb2f91c3b9d8b27ee2|Matt Poole|feature/BSD-58-reuse-section-for-wra
 65de35fce0fecb7d5ada406734759296|Matt Poole|feature/BSD-58-reuse-section-for-wrapper|Mon Jan 29 16:40:12 EST 2024|./composer.sh update --lock
 c40b2c85e6e96b0e5de8aa649eb6477d|Matt Poole|feature/BSD-16-footer-refinements|Fri Mar  1 15:21:03 EST 2024|./composer.sh require drupal/imagecache_external:^3.0
 f996e536d04232a5a8b1c61a6563d846|Buddy Harlow|feature/BSD-103-install-chosen-module|Fri Mar 15 11:03:26 UTC 2024|./composer.sh require drupal/chosen:^4.0
+927e55f6845342cbcbf351c3a91af45e|Matt Poole|feature/BSD-103-install-chosen-module|Mon Mar 18 15:48:01 EDT 2024|./composer.sh require jjj/chosen:2.2.1

--- a/composer.log
+++ b/composer.log
@@ -5,3 +5,4 @@ a63449fcce1213de3c590678ddc1bd17|Buddy Harlow|feature/BSD-12-scaffold-drupal-the
 a42621d48ea57cbb2f91c3b9d8b27ee2|Matt Poole|feature/BSD-58-reuse-section-for-wrapper|Mon Jan 29 16:40:12 EST 2024|./composer.sh require cweagans/composer-patches
 65de35fce0fecb7d5ada406734759296|Matt Poole|feature/BSD-58-reuse-section-for-wrapper|Mon Jan 29 16:40:12 EST 2024|./composer.sh update --lock
 c40b2c85e6e96b0e5de8aa649eb6477d|Matt Poole|feature/BSD-16-footer-refinements|Fri Mar  1 15:21:03 EST 2024|./composer.sh require drupal/imagecache_external:^3.0
+f996e536d04232a5a8b1c61a6563d846|Buddy Harlow|feature/BSD-103-install-chosen-module|Fri Mar 15 11:03:26 UTC 2024|./composer.sh require drupal/chosen:^4.0

--- a/config/sync/chosen.settings.yml
+++ b/config/sync/chosen.settings.yml
@@ -1,0 +1,21 @@
+_core:
+  default_config_hash: exRaKE0s6uZbfQrl_2WFEcTlc_1t81xEqCLuCCteUSk
+minimum_single: 0
+minimum_multiple: 0
+disable_search_threshold: 0
+minimum_width: 400
+max_shown_results: null
+use_relative_width: false
+jquery_selector: 'select:visible'
+search_contains: false
+disable_search: false
+allow_single_deselect: false
+disabled_themes:
+  claro: '0'
+  olivero: '0'
+  stark: '0'
+  bixal_uswds: '0'
+chosen_include: 2
+placeholder_text_multiple: 'Choose some options'
+placeholder_text_single: 'Choose an option'
+no_results_text: 'No results match'

--- a/config/sync/chosen.settings.yml
+++ b/config/sync/chosen.settings.yml
@@ -7,15 +7,15 @@ minimum_width: 400
 max_shown_results: null
 use_relative_width: false
 jquery_selector: 'select:visible'
-search_contains: false
+search_contains: true
 disable_search: false
 allow_single_deselect: false
 disabled_themes:
+  bixal_uswds: bixal_uswds
   claro: '0'
   olivero: '0'
   stark: '0'
-  bixal_uswds: '0'
-chosen_include: 2
+chosen_include: 0
 placeholder_text_multiple: 'Choose some options'
 placeholder_text_single: 'Choose an option'
 no_results_text: 'No results match'

--- a/config/sync/core.entity_form_display.node.bixaler.default.yml
+++ b/config/sync/core.entity_form_display.node.bixaler.default.yml
@@ -48,14 +48,10 @@ content:
       placeholder: ''
     third_party_settings: {  }
   field_certifications:
-    type: entity_reference_autocomplete_tags
+    type: options_select
     weight: 123
     region: content
-    settings:
-      match_operator: CONTAINS
-      match_limit: 10
-      size: 60
-      placeholder: ''
+    settings: {  }
     third_party_settings: {  }
   field_image:
     type: media_library_widget
@@ -65,14 +61,10 @@ content:
       media_types: {  }
     third_party_settings: {  }
   field_languages:
-    type: entity_reference_autocomplete_tags
+    type: options_select
     weight: 124
     region: content
-    settings:
-      match_operator: CONTAINS
-      match_limit: 10
-      size: 60
-      placeholder: ''
+    settings: {  }
     third_party_settings: {  }
   field_link:
     type: link_default
@@ -83,34 +75,22 @@ content:
       placeholder_title: ''
     third_party_settings: {  }
   field_role:
-    type: entity_reference_autocomplete_tags
+    type: options_select
     weight: 126
     region: content
-    settings:
-      match_operator: CONTAINS
-      match_limit: 10
-      size: 60
-      placeholder: ''
+    settings: {  }
     third_party_settings: {  }
   field_specialties:
-    type: entity_reference_autocomplete_tags
+    type: options_select
     weight: 122
     region: content
-    settings:
-      match_operator: CONTAINS
-      match_limit: 10
-      size: 60
-      placeholder: ''
+    settings: {  }
     third_party_settings: {  }
   field_team:
-    type: entity_reference_autocomplete_tags
+    type: options_select
     weight: 125
     region: content
-    settings:
-      match_operator: CONTAINS
-      match_limit: 10
-      size: 60
-      placeholder: ''
+    settings: {  }
     third_party_settings: {  }
   langcode:
     type: language_select

--- a/config/sync/core.extension.yml
+++ b/config/sync/core.extension.yml
@@ -9,6 +9,8 @@ module:
   block: 0
   block_node: 0
   breakpoint: 0
+  chosen: 0
+  chosen_lib: 0
   ckeditor5: 0
   components: 0
   contextual: 0


### PR DESCRIPTION
## Added chosen module and configured it for taxonomy reference fields (Bixaler)

*Notes for testing*
- lando start && lando si
- Go to this page -> http://bixalcom.lndo.site/admin/config/user-interface/chosen
- If you see an error message regarding the library, run 'drush chosenplugin', this is what I had to run to get it to work, however I couldn't replicate the error message by deleting vendor so I assume it is added somewhere. If that is the case, maybe we have to add that command after set-hp.
- Add a bixaler to see the module in action