### PR TITLE
BSD closes #102: Created site-admin role, created site-admin test user

### DIFF
--- a/config/sync/system.action.user_add_role_action.site_admin.yml
+++ b/config/sync/system.action.user_add_role_action.site_admin.yml
@@ -1,0 +1,14 @@
+uuid: c9a4e8b0-04fa-4b1d-a4fe-bb00f2d34da8
+langcode: en
+status: true
+dependencies:
+  config:
+    - user.role.site_admin
+  module:
+    - user
+id: user_add_role_action.site_admin
+label: 'Add the Site-Admin role to the selected user(s)'
+type: user
+plugin: user_add_role_action
+configuration:
+  rid: site_admin

--- a/config/sync/system.action.user_remove_role_action.site_admin.yml
+++ b/config/sync/system.action.user_remove_role_action.site_admin.yml
@@ -1,0 +1,14 @@
+uuid: c8b971e5-e6ec-40b8-b3d3-9b50b18e7ba4
+langcode: en
+status: true
+dependencies:
+  config:
+    - user.role.site_admin
+  module:
+    - user
+id: user_remove_role_action.site_admin
+label: 'Remove the Site-Admin role from the selected user(s)'
+type: user
+plugin: user_remove_role_action
+configuration:
+  rid: site_admin

--- a/config/sync/system.site.yml
+++ b/config/sync/system.site.yml
@@ -12,3 +12,4 @@ page:
 admin_compact_mode: false
 weight_select_max: 100
 default_langcode: en
+mail_notification: ''

--- a/config/sync/user.mail.yml
+++ b/config/sync/user.mail.yml
@@ -3,114 +3,28 @@ _core:
 langcode: en
 cancel_confirm:
   subject: 'Account cancellation request for [user:display-name] at [site:name]'
-  body: |-
-    [user:display-name]
-
-    A request to cancel your account has been made at [site:name].
-
-    You may now cancel your account on [site:url-brief] by clicking this link or copying and pasting it into your browser:
-
-    [user:cancel-url]
-
-    NOTE: The cancellation of your account is not reversible.
-
-    This link expires in one day and nothing will happen if it is not used.
-
-    --  [site:name] team
+  body: "[user:display-name]\r\n\r\nA request to cancel your account has been made at [site:name].\r\n\r\nYou may now cancel your account on [site:url-brief] by clicking this link or copying and pasting it into your browser:\r\n\r\n[user:cancel-url]\r\n\r\nNOTE: The cancellation of your account is not reversible.\r\n\r\nThis link expires in one day and nothing will happen if it is not used.\r\n\r\n--  [site:name] team"
 password_reset:
   subject: 'Replacement login information for [user:display-name] at [site:name]'
-  body: |-
-    [user:display-name],
-
-    A request to reset the password for your account has been made at [site:name].
-
-    You may now log in by clicking this link or copying and pasting it into your browser:
-
-    [user:one-time-login-url]
-
-    This link can only be used once to log in and will lead you to a page where you can set your password. It expires after one day and nothing will happen if it's not used.
-
-    --  [site:name] team
+  body: "[user:display-name],\r\n\r\nA request to reset the password for your account has been made at [site:name].\r\n\r\nYou may now log in by clicking this link or copying and pasting it into your browser:\r\n\r\n[user:one-time-login-url]\r\n\r\nThis link can only be used once to log in and will lead you to a page where you can set your password. It expires after one day and nothing will happen if it's not used.\r\n\r\n--  [site:name] team"
 register_admin_created:
   subject: 'An administrator created an account for you at [site:name]'
-  body: |-
-    [user:display-name],
-
-    A site administrator at [site:name] has created an account for you. You may now log in by clicking this link or copying and pasting it into your browser:
-
-    [user:one-time-login-url]
-
-    This link can only be used once to log in and will lead you to a page where you can set your password.
-
-    After setting your password, you will be able to log in at [site:login-url] in the future using:
-
-    username: [user:name]
-    password: Your password
-
-    --  [site:name] team
+  body: "[user:display-name],\r\n\r\nA site administrator at [site:name] has created an account for you. You may now log in by clicking this link or copying and pasting it into your browser:\r\n\r\n[user:one-time-login-url]\r\n\r\nThis link can only be used once to log in and will lead you to a page where you can set your password.\r\n\r\nAfter setting your password, you will be able to log in at [site:login-url] in the future using:\r\n\r\nusername: [user:name]\r\npassword: Your password\r\n\r\n--  [site:name] team"
 register_no_approval_required:
   subject: 'Account details for [user:display-name] at [site:name]'
-  body: |-
-    [user:display-name],
-
-    Thank you for registering at [site:name]. You may now log in by clicking this link or copying and pasting it into your browser:
-
-    [user:one-time-login-url]
-
-    This link can only be used once to log in and will lead you to a page where you can set your password.
-
-    After setting your password, you will be able to log in at [site:login-url] in the future using:
-
-    username: [user:name]
-    password: Your password
-
-    --  [site:name] team
+  body: "[user:display-name],\r\n\r\nThank you for registering at [site:name]. You may now log in by clicking this link or copying and pasting it into your browser:\r\n\r\n[user:one-time-login-url]\r\n\r\nThis link can only be used once to log in and will lead you to a page where you can set your password.\r\n\r\nAfter setting your password, you will be able to log in at [site:login-url] in the future using:\r\n\r\nusername: [user:name]\r\npassword: Your password\r\n\r\n--  [site:name] team"
 register_pending_approval:
   subject: 'Account details for [user:display-name] at [site:name] (pending admin approval)'
-  body: |-
-    [user:display-name],
-
-    Thank you for registering at [site:name]. Your application for an account is currently pending approval. Once it has been approved, you will receive another email containing information about how to log in, set your password, and other details.
-
-    --  [site:name] team
+  body: "[user:display-name],\r\n\r\nThank you for registering at [site:name]. Your application for an account is currently pending approval. Once it has been approved, you will receive another email containing information about how to log in, set your password, and other details.\r\n\r\n--  [site:name] team"
 register_pending_approval_admin:
   subject: 'Account details for [user:display-name] at [site:name] (pending admin approval)'
-  body: |-
-    [user:display-name] has applied for an account.
-
-    [user:edit-url]
+  body: "[user:display-name] has applied for an account.\r\n\r\n[user:edit-url]"
 status_activated:
   subject: 'Account details for [user:display-name] at [site:name] (approved)'
-  body: |-
-    [user:display-name],
-
-    Your account at [site:name] has been activated.
-
-    You may now log in by clicking this link or copying and pasting it into your browser:
-
-    [user:one-time-login-url]
-
-    This link can only be used once to log in and will lead you to a page where you can set your password.
-
-    After setting your password, you will be able to log in at [site:login-url] in the future using:
-
-    username: [user:account-name]
-    password: Your password
-
-    --  [site:name] team
+  body: "[user:display-name],\r\n\r\nYour account at [site:name] has been activated.\r\n\r\nYou may now log in by clicking this link or copying and pasting it into your browser:\r\n\r\n[user:one-time-login-url]\r\n\r\nThis link can only be used once to log in and will lead you to a page where you can set your password.\r\n\r\nAfter setting your password, you will be able to log in at [site:login-url] in the future using:\r\n\r\nusername: [user:account-name]\r\npassword: Your password\r\n\r\n--  [site:name] team"
 status_blocked:
   subject: 'Account details for [user:display-name] at [site:name] (blocked)'
-  body: |-
-    [user:display-name],
-
-    Your account on [site:name] has been blocked.
-
-    --  [site:name] team
+  body: "[user:display-name],\r\n\r\nYour account on [site:name] has been blocked.\r\n\r\n--  [site:name] team"
 status_canceled:
   subject: 'Account details for [user:display-name] at [site:name] (canceled)'
-  body: |-
-    [user:display-name],
-
-    Your account on [site:name] has been canceled.
-
-    --  [site:name] team
+  body: "[user:display-name],\r\n\r\nYour account on [site:name] has been canceled.\r\n\r\n--  [site:name] team"

--- a/config/sync/user.role.site_admin.yml
+++ b/config/sync/user.role.site_admin.yml
@@ -1,0 +1,20 @@
+uuid: 7b364043-2cb7-424e-8bb2-86faa8e4bb6b
+langcode: en
+status: true
+dependencies:
+  module:
+    - admin_toolbar_search
+    - role_delegation
+    - system
+    - toolbar
+id: site_admin
+label: Site-Admin
+weight: 3
+is_admin: null
+permissions:
+  - 'access administration pages'
+  - 'access toolbar'
+  - 'administer users'
+  - 'assign editor role'
+  - 'use admin toolbar search'
+  - 'view the administration theme'

--- a/config/sync/user.settings.yml
+++ b/config/sync/user.settings.yml
@@ -2,7 +2,7 @@ _core:
   default_config_hash: '-htDFWUv1S4OlJMzta2nhFl4QbhJvu0D9xsJ-clxo-M'
 langcode: en
 anonymous: Anonymous
-verify_mail: true
+verify_mail: false
 notify:
   cancel_confirm: true
   password_reset: true
@@ -12,7 +12,7 @@ notify:
   register_admin_created: true
   register_no_approval_required: true
   register_pending_approval: true
-register: visitors_admin_approval
-cancel_method: user_cancel_block
+register: admin_only
+cancel_method: user_cancel_reassign
 password_reset_timeout: 86400
 password_strength: true

--- a/web/modules/custom/bixal_default_content/content/user/abd579e2-1336-437d-9c29-d7cee2076b71.yml
+++ b/web/modules/custom/bixal_default_content/content/user/abd579e2-1336-437d-9c29-d7cee2076b71.yml
@@ -1,0 +1,38 @@
+_meta:
+  version: "1.0"
+  entity_type: user
+  uuid: abd579e2-1336-437d-9c29-d7cee2076b71
+  default_langcode: en
+default:
+  preferred_langcode:
+    - value: en
+  preferred_admin_langcode:
+    - value: en
+  name:
+    - value: site-admin
+  pass:
+    - value: $2y$10$TCAl0M0SiaXgaSJkv5RM0.FuIc7ikQr2bhBlGscEob.dxooE9RhxS
+      existing: ""
+      pre_hashed: true
+  mail:
+    - value: site-admin@bixal.com
+  timezone:
+    - value: UTC
+  status:
+    - value: true
+  created:
+    - value: 1710506572
+  access:
+    - value: 1710506589
+  login:
+    - value: 1710506589
+  init:
+    - value: site-admin@bixal.com
+  roles:
+    - target_id: site_admin
+  role_change:
+    - target_id: __role_delegation_empty_field_value__
+  path:
+    - alias: ""
+      langcode: en
+      pathauto: 0


### PR DESCRIPTION
## Created site-admin role, configured permissions, exported 'site-admin' user ##

_Notes_
- un: site-admin pw: site-admin
- had to grant access to admin theme and menus but the only thing available is adding editors
- Changed some site settings for registration and removal of user shifts content to user 1