### PR TITLE
BSD fixes #119: Image styles on bixaler people-list and bixaler node.

### DIFF
--- a/config/sync/core.entity_view_display.node.bixaler.default.yml
+++ b/config/sync/core.entity_view_display.node.bixaler.default.yml
@@ -12,9 +12,11 @@ dependencies:
     - field.field.node.bixaler.field_role
     - field.field.node.bixaler.field_specialties
     - field.field.node.bixaler.field_team
+    - image.style.bixaler_thumbnail
     - node.type.bixaler
   module:
     - link
+    - media
     - user
 id: node.bixaler.default
 targetEntityType: node
@@ -37,11 +39,13 @@ content:
     weight: 2
     region: content
   field_image:
-    type: entity_reference_entity_view
+    type: media_thumbnail
     label: hidden
     settings:
-      view_mode: default
-      link: false
+      image_link: ''
+      image_style: bixaler_thumbnail
+      image_loading:
+        attribute: lazy
     third_party_settings: {  }
     weight: 7
     region: content

--- a/config/sync/image.style.bixaler_thumbnail.yml
+++ b/config/sync/image.style.bixaler_thumbnail.yml
@@ -1,0 +1,15 @@
+uuid: 32da28cb-6c20-4bfd-a709-cf08f8ca871d
+langcode: en
+status: true
+dependencies: {  }
+name: bixaler_thumbnail
+label: 'Bixaler Thumbnail'
+effects:
+  ad71a4a6-7c0f-4756-9efc-34608f04687b:
+    uuid: ad71a4a6-7c0f-4756-9efc-34608f04687b
+    id: image_scale_and_crop
+    weight: 1
+    data:
+      width: 325
+      height: 325
+      anchor: center-center

--- a/web/themes/custom/bixal_uswds/php-includes/paragraphs.inc
+++ b/web/themes/custom/bixal_uswds/php-includes/paragraphs.inc
@@ -6,6 +6,7 @@
  */
 
 use Drupal\Core\Entity\FieldableEntityInterface;
+use Drupal\image\Entity\ImageStyle;
 use Drupal\node\Entity\Node;
 use Drupal\node\NodeInterface;
 use Drupal\taxonomy\Entity\Term;
@@ -98,10 +99,12 @@ function bixal_uswds_preprocess_paragraph(&$vars) {
           if (!$field_ne_and_exists($media_entity, 'field_media_image')) {
             return '';
           }
+
           $file_entity = $media_entity->get('field_media_image')->entity;
           // Get the URL of the media file.
           $uri = $file_entity->getFileUri();
-          return \Drupal::service('file_url_generator')->generateAbsoluteString($uri);
+          $url = ImageStyle::load('bixaler_thumbnail')->buildUrl($uri);
+          return $url;
         };
 
         $get_first_term_ref_title = static function (NodeInterface $node, $field_name) use (&$field_ne_and_exists) {


### PR DESCRIPTION
Configured an image style for bixaler and enabled it within the display for full content, and edited the paragraph.inc to utilize it for people-list paragraph. To test, add a bixaler and use one of the banner images at the bixaler image. Check node full page of that bixaler, and in the people list on about.