### PR TITLE
BSD closes #174: Changed field to true/false, fixed var in template, set a default.

### DIFF
--- a/config/sync/core.entity_view_display.paragraph.blurb_collection.default.yml
+++ b/config/sync/core.entity_view_display.paragraph.blurb_collection.default.yml
@@ -35,7 +35,7 @@ content:
     type: boolean
     label: above
     settings:
-      format: default
+      format: true-false
       format_custom_false: ''
       format_custom_true: ''
     third_party_settings: {  }

--- a/config/sync/field.field.paragraph.blurb_collection.field_featured.yml
+++ b/config/sync/field.field.paragraph.blurb_collection.field_featured.yml
@@ -13,7 +13,9 @@ label: Featured
 description: ''
 required: false
 translatable: false
-default_value: {  }
+default_value:
+  -
+    value: 0
 default_value_callback: ''
 settings:
   on_label: 'On'

--- a/web/themes/custom/bixal_uswds/templates/paragraphs/paragraph--blurb-collection.html.twig
+++ b/web/themes/custom/bixal_uswds/templates/paragraphs/paragraph--blurb-collection.html.twig
@@ -41,11 +41,13 @@
 {# @todo: Add a field to blurb collection that is a boolean for 'featured', it is an option to blurb-collection-base
   and makes the first blurb full width.
 #}
+
+
 {% block paragraph %}
   {% include '@components/blurb/blurb-collection-base.html.twig' with {
     'blurb_collection': content.field_blurbs | field_value,
     'variant': content.field_blurb_collection_variant['#items'].getString(),
-    'featured': content.field_featured.0['#markup'],
+    'featured': content.field_featured['#items'].value,
     'additional_classes': [
       'component',
       'component--type--' ~ paragraph.bundle|clean_class,


### PR DESCRIPTION
Real interesting problem here! So the way it was checking for featured was if the field existed. This works for some things, however if 'featured' was ever checked regardless of switching back, the field would have some value in it. You can switch to featured in a dev environment, then switch it back and it'll stay as featured. This PR should fix that issue!