### PR TITLE
BSD fixes #177: Use already existing variables and ability to have 'l…

### DIFF
--- a/config/sync/core.entity_view_display.node.contract_vehicle.teaser.yml
+++ b/config/sync/core.entity_view_display.node.contract_vehicle.teaser.yml
@@ -24,10 +24,10 @@ content:
     label: hidden
     settings:
       trim_length: 80
-      url_only: false
-      url_plain: false
-      rel: ''
-      target: ''
+      url_only: true
+      url_plain: true
+      rel: '0'
+      target: '0'
     third_party_settings: {  }
     weight: 1
     region: content

--- a/web/themes/custom/bixal_uswds/templates/node/node--contract-vehicle--teaser.html.twig
+++ b/web/themes/custom/bixal_uswds/templates/node/node--contract-vehicle--teaser.html.twig
@@ -77,10 +77,10 @@
   view_mode ? 'node--view-mode-' ~ view_mode|clean_class,
 ]
 %}
-{% if content.field_link_to_content.0['#title'] is not empty %}
-  {% set content_link = content.field_link_to_content.0['#title'] %}
+{% if content.field_link_to_content | field_value %}
+  {% set content_link = content.field_link_to_content | field_value %}
 {% else %}
-  {% set content_link = path('entity.node.canonical', {'node': node.id}) %}
+  {% set content_link = url %}
 {% endif %}
 
 <article{{attributes.addClass(classes)}}>


### PR DESCRIPTION
…ink only' for the link to content.

I updated the teaser view so that the field just outputs a plain text URL
![image](https://github.com/Bixal/bixal-site-drupal/assets/121190622/b170ac14-7186-4f61-9aa7-0618ba7e9cef)
I also used the built in `url` variable so that the link would not need to be created again non redirecting nodes.