### PR TITLE
BSD fixes #178: Can't extend a component, extending section paragraph…

### DIFF
--- a/web/themes/custom/bixal_uswds/templates/paragraphs/paragraph--section-wrapper.html.twig
+++ b/web/themes/custom/bixal_uswds/templates/paragraphs/paragraph--section-wrapper.html.twig
@@ -52,7 +52,7 @@
   not paragraph.isPublished() ?  'component--unpublished'
 ] %}
 
-{% extends  "@components/section/section.html.twig" %}
+{% extends  "paragraph--section.html.twig" %}
 
 {% block body %}
   <div{{attributes.addClass(classes)}}>


### PR DESCRIPTION
… instead.

I totally forgot that we had 'section' paragraphs in order to allow us to put stuff full screen or not. However, when I was testing, I found 'Section Wrapper' and it seemed to output no content until I made this change. Section seems to be just like section except it allows a variant, is that right?
