### PR TITLE
BSD fixes #194: If using 'URL Plain', then the trimming applies to th…

### DIFF
--- a/config/sync/core.entity_view_display.node.contract_vehicle.teaser.yml
+++ b/config/sync/core.entity_view_display.node.contract_vehicle.teaser.yml
@@ -23,7 +23,7 @@ content:
     type: link
     label: hidden
     settings:
-      trim_length: 80
+      trim_length: null
       url_only: true
       url_plain: true
       rel: '0'


### PR DESCRIPTION
…e output, wild.