### PR TITLE
BSD fixes #202: Allow access to webp files in the default route on platform

### DIFF
--- a/.platform.app.yaml
+++ b/.platform.app.yaml
@@ -146,7 +146,7 @@ web:
       # Rules for specific URI patterns.
       rules:
         # Allow access to common static files.
-        '\.(jpe?g|png|gif|svgz?|css|js|map|ico|bmp|eot|woff2?|otf|ttf)$':
+        '\.(jpe?g|png|gif|svgz?|css|js|map|ico|bmp|eot|woff2?|otf|ttf|webp)$':
           allow: true
         '^/robots\.txt$':
           allow: true


### PR DESCRIPTION
See https://feature-bsd-202-webp-f5a6foa-tsvj5tw7p3f66.us.platformsh.site/our-work/sba for working images now in the contract vehicles.