### PR TITLE
Feature/bsd 199 view all after filter

### DIFF
--- a/.lando.yml
+++ b/.lando.yml
@@ -102,6 +102,10 @@ tooling:
       - "./orch/deploy_shared_install.sh"
       - "./orch/post_deploy_shared.sh"
       - "drush uli"
+  watch:
+    service: node
+    cmd:
+      - 'cd web/themes/custom/bixal_uswds && npm run gulp'
   xdebug-on:
     service: appserver
     description: Enable Xdebug.

--- a/sb.sh
+++ b/sb.sh
@@ -4,4 +4,4 @@ cd "$(dirname "$0")" || exit
 
 npm install
 npm run build-storybook
-npm run storybook:local
+NODE_OPTIONS="--max-old-space-size=8192" npm run storybook:local

--- a/stories/components/people-list/people-list.js
+++ b/stories/components/people-list/people-list.js
@@ -11,7 +11,7 @@ window.addEventListener("DOMContentLoaded", () => {
   if (!filterItems) {
     return;
   }
-  const viewAllButton = document.querySelector('.bix-people__footer').children[0];
+  const footer = document.querySelector('.bix-people__footer');
 
   /**
    * Basic content filtering.
@@ -25,6 +25,10 @@ window.addEventListener("DOMContentLoaded", () => {
     if (!isOption) {
       return;
     }
+    // After a filter is chosen, hide the popup.
+    Toggle.hide(trigger, target)
+    // If a filter is chosen, show all results and hide the 'view all' button.
+    removeContentLimit();
 
     const option = event.target;
     const chosenFilterValue = option.getAttribute("for");
@@ -49,15 +53,21 @@ window.addEventListener("DOMContentLoaded", () => {
 
   /**
    * Remove content number limit.
-   *
-   * @param {Event} event
    */
-  function removeContentLimit(event) {
+  function removeContentLimit() {
+    const footer = document.querySelector('.bix-people__footer');
+    if (!footer) {
+      return;
+    }
+    const style = window.getComputedStyle(footer);
+    if (style.visibility === 'hidden') {
+      return;
+    }
     const hiddenExtraItems = document.querySelectorAll(".view-all-only");
     [...hiddenExtraItems].map(person => {
       person.classList.remove('view-all-only');
     });
-    document.querySelector('.bix-people__footer').setAttribute("hidden", "");
+    footer.setAttribute("hidden", "");
   }
 
   /**
@@ -68,7 +78,10 @@ window.addEventListener("DOMContentLoaded", () => {
 
     trigger.addEventListener("click", Toggle.toggle);
     target.addEventListener("click", filterContent);
-    viewAllButton.addEventListener("click", removeContentLimit);
+    // Add a click event to the 'View All' button.
+    if (footer) {
+      footer.children[0].addEventListener("click", removeContentLimit);
+    }
   }
 
   init();


### PR DESCRIPTION
This fixes a JS error if the view all button was not there.
When a filter option is chosen: Treat as though 'View all' is clicked. Also, hide the filter popup.