### PR TITLE
BSD fixes #171: Changed from AC deluxe to AC tags, added link to add …

### DIFF
--- a/config/sync/core.entity_form_display.node.bixaler.default.yml
+++ b/config/sync/core.entity_form_display.node.bixaler.default.yml
@@ -14,7 +14,6 @@ dependencies:
     - field.field.node.bixaler.field_team
     - node.type.bixaler
   module:
-    - autocomplete_deluxe
     - link
     - media_library
     - path
@@ -38,21 +37,14 @@ content:
       placeholder: ''
     third_party_settings: {  }
   field_certifications:
-    type: autocomplete_deluxe
+    type: entity_reference_autocomplete_tags
     weight: 10
     region: content
     settings:
       match_operator: CONTAINS
-      autocomplete_route_name: autocomplete_deluxe.autocomplete
+      match_limit: 10
       size: 60
-      selection_handler: default
-      limit: 10
-      min_length: 0
-      delimiter: ''
-      not_found_message_allow: false
-      not_found_message: "The certification '@term' will be added"
-      new_terms: true
-      no_empty_message: 'No terms could be found. Please type in order to add a new term.'
+      placeholder: ''
     third_party_settings: {  }
   field_image:
     type: media_library_widget
@@ -62,21 +54,14 @@ content:
       media_types: {  }
     third_party_settings: {  }
   field_languages:
-    type: autocomplete_deluxe
+    type: entity_reference_autocomplete_tags
     weight: 11
     region: content
     settings:
       match_operator: CONTAINS
-      autocomplete_route_name: autocomplete_deluxe.autocomplete
+      match_limit: 10
       size: 60
-      selection_handler: default
-      limit: 10
-      min_length: 0
-      delimiter: ''
-      not_found_message_allow: false
-      not_found_message: "The language '@term' will be added"
-      new_terms: true
-      no_empty_message: 'No terms could be found. Please type in order to add a new term.'
+      placeholder: ''
     third_party_settings: {  }
   field_link:
     type: link_default
@@ -87,55 +72,34 @@ content:
       placeholder_title: ''
     third_party_settings: {  }
   field_role:
-    type: autocomplete_deluxe
+    type: entity_reference_autocomplete_tags
     weight: 13
     region: content
     settings:
       match_operator: CONTAINS
-      autocomplete_route_name: autocomplete_deluxe.autocomplete
+      match_limit: 10
       size: 60
-      selection_handler: default
-      limit: 10
-      min_length: 0
-      delimiter: ''
-      not_found_message_allow: false
-      not_found_message: "The role '@term' will be added"
-      new_terms: true
-      no_empty_message: 'No terms could be found. Please type in order to add a new term.'
+      placeholder: ''
     third_party_settings: {  }
   field_specialties:
-    type: autocomplete_deluxe
+    type: entity_reference_autocomplete_tags
     weight: 9
     region: content
     settings:
       match_operator: CONTAINS
-      autocomplete_route_name: autocomplete_deluxe.autocomplete
+      match_limit: 10
       size: 60
-      selection_handler: default
-      limit: 10
-      min_length: 0
-      delimiter: ''
-      not_found_message_allow: false
-      not_found_message: "The specialty '@term' will be added"
-      new_terms: true
-      no_empty_message: 'No terms could be found. Please type in order to add a new term.'
+      placeholder: ''
     third_party_settings: {  }
   field_team:
-    type: autocomplete_deluxe
+    type: entity_reference_autocomplete_tags
     weight: 12
     region: content
     settings:
       match_operator: CONTAINS
-      autocomplete_route_name: autocomplete_deluxe.autocomplete
+      match_limit: 10
       size: 60
-      selection_handler: default
-      limit: 10
-      min_length: 0
-      delimiter: ''
-      not_found_message_allow: true
-      not_found_message: "The team '@term' cannot be found"
-      new_terms: false
-      no_empty_message: 'No terms could be found. Please type in order to add a new term.'
+      placeholder: ''
     third_party_settings: {  }
   langcode:
     type: language_select

--- a/config/sync/field.field.node.bixaler.field_certifications.yml
+++ b/config/sync/field.field.node.bixaler.field_certifications.yml
@@ -11,7 +11,7 @@ field_name: field_certifications
 entity_type: node
 bundle: bixaler
 label: Certifications
-description: ''
+description: 'If the term you wish to use does not exist, please visit the <a href="/admin/structure/taxonomy/manage/certifications/add">certifications vocabulary addition page</a> to add the new term.'
 required: false
 translatable: false
 default_value: {  }

--- a/config/sync/field.field.node.bixaler.field_languages.yml
+++ b/config/sync/field.field.node.bixaler.field_languages.yml
@@ -11,7 +11,7 @@ field_name: field_languages
 entity_type: node
 bundle: bixaler
 label: Languages
-description: ''
+description: 'If the term you wish to use does not exist, please visit the <a href="/admin/structure/taxonomy/manage/languages/add">languages vocabulary addition page</a> to add the new term.'
 required: false
 translatable: false
 default_value: {  }

--- a/config/sync/field.field.node.bixaler.field_role.yml
+++ b/config/sync/field.field.node.bixaler.field_role.yml
@@ -11,7 +11,7 @@ field_name: field_role
 entity_type: node
 bundle: bixaler
 label: Role
-description: ''
+description: 'If the term you wish to use does not exist, please visit the <a href="/admin/structure/taxonomy/manage/role/add">role vocabulary addition page</a> to add the new term.'
 required: false
 translatable: false
 default_value: {  }

--- a/config/sync/field.field.node.bixaler.field_specialties.yml
+++ b/config/sync/field.field.node.bixaler.field_specialties.yml
@@ -11,7 +11,7 @@ field_name: field_specialties
 entity_type: node
 bundle: bixaler
 label: Specialties
-description: ''
+description: 'If the term you wish to use does not exist, please visit the <a href="/admin/structure/taxonomy/manage/specialties/add">specialties vocabulary addition page</a> to add the new term.'
 required: false
 translatable: false
 default_value: {  }

--- a/config/sync/field.field.node.bixaler.field_team.yml
+++ b/config/sync/field.field.node.bixaler.field_team.yml
@@ -11,7 +11,7 @@ field_name: field_team
 entity_type: node
 bundle: bixaler
 label: Team
-description: ''
+description: 'If the term you wish to use does not exist, please visit the <a href="/admin/structure/taxonomy/manage/team/add">team vocabulary addition page</a> to add the new term.'
 required: false
 translatable: false
 default_value: {  }


### PR DESCRIPTION
- Changed from Automcomplete deluxe to tags style autocomplete
- Added the vocab addition URL to the description of tag fields when adding a bixaler
- Fixes the use of parenthetical issue