### PR TITLE
BSD fixes #232: Use only uswds core and usa skipnav instead of ALL of all uswds components.

### DIFF
--- a/web/themes/custom/bixal_uswds/src/sass/styles.scss
+++ b/web/themes/custom/bixal_uswds/src/sass/styles.scss
@@ -5,7 +5,8 @@
 
 // USWDS individual components
 // to include everything, just code it as @forward "uswds";
-@forward "uswds";
+@forward "uswds-core";
+@forward "usa-skipnav";
 
 // Custom styles
 @forward "uswds-theme-custom-styles";

--- a/web/themes/custom/bixal_uswds/templates/layout/html.html.twig
+++ b/web/themes/custom/bixal_uswds/templates/layout/html.html.twig
@@ -46,7 +46,7 @@
 Keyboard navigation/accessibility link to main content section in
 page.html.twig.
 #}
-<a href="#main-content" class="usa-skipnav">
+<a href="#main-content" class="usa-skipnav skip-link visually-hidden focusable">
   {{ 'Skip to main content'|t }}
 </a>
 {{ page_top }}


### PR DESCRIPTION
Super tiny now
![image](https://github.com/user-attachments/assets/fb986bd0-97a3-403a-b504-9c19da5ac236)

https://pr-233-imhdbhq-tsvj5tw7p3f66.us.platformsh.site/
