### PR TITLE
BSD fixes #295: Add branch and commit guidance to README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,8 @@ It's important that you always use `lando composer` or `./composer.sh` instead o
 
 ### Access story book
 
+[Storybook preview is available here →](https://sb.feature-bsd-286-remote-xcrmjai-tsvj5tw7p3f66.us.platformsh.site) 
+
 [Storybook](https://storybook.js.org/) for this project can be found by:
 
 - Docker version: http://storybook.bixalcom.lndo.site/

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ lando build
 lando si
 ```
 
-This will install all the sample content we have created in web/modules/custom/bixal_default_content. In order to export new content here, create it locally and run ```lando export-content```.
+This will install all the sample content we have created in `web/modules/custom/bixal_default_content`. In order to export new content here, create it locally and run `lando export-content`.
 
 ### Running Drush
 
@@ -81,6 +81,6 @@ It's important that you always use `lando composer` or `./composer.sh` instead o
 
 - Run all the validation commands that the pipelines run without needing to push remotely `vendor/bin/robo validate:all`.
 
-#### Configure  Xdebug
+#### Configure Xdebug
 
 https://github.com/mattsqd/drupal-env-lando/wiki/XDebug-(Personal)

--- a/README.md
+++ b/README.md
@@ -8,6 +8,40 @@ The remote environments are hosted in platform.sh. See the ./.platform directory
 
 The local environment is based on [Drupal Env](https://github.com/mattsqd/drupal-env/wiki) and the [Drupal Env Lando](https://github.com/mattsqd/drupal-env-lando/wiki) packages.
 
+## Branching
+
+Use the following naming for your git branches.
+
+```sh
+feature/BSD-[ISSUE_NO]-[LOWER_CASE_DESCRIPTION]
+```
+
+**Example**
+
+```sh
+feature/BSD-64-robo-validate
+```
+
+## Commit style
+
+```sh
+BSD fixes #64: Fixed coding standards issues.
+```
+
+Also acceptable:
+
+- close, closes, closed
+- fix, fixes, fixed
+- resolve, resolves, resolved
+
+Example:
+
+```
+BSD closes #64: Fixed coding standards issues.
+```
+
+More guidance on git branches and commit style in [robo.yml](https://github.com/Bixal/bixal-site-drupal/blob/develop/robo.yml)
+
 ### Starting the Environment
 
 First time:


### PR DESCRIPTION
This PR updates the README.md with guidance on branch and commit conventions. As well as a preview link to the storybook preview.

Helpful to those wanting to contribute to the codebase. Based on guidance in `robo.yml`.

Closes #295.