### PR TITLE
BSD fixes #318: Upload file size limit

### DIFF
--- a/.platform/applications.yaml
+++ b/.platform/applications.yaml
@@ -32,8 +32,8 @@ bixalcom:
     env:
       N_PREFIX: /app/.global
     php:
-      post_max_size: '90M'
-      upload_max_filesize: '90M'
+      post_max_size: '300M'
+      upload_max_filesize: '300M'
 
   # The relationships of the application with services or other applications.
   #

--- a/.platform/applications.yaml
+++ b/.platform/applications.yaml
@@ -161,10 +161,10 @@ bixalcom:
         # Redirect any incoming request to Drupal's front controller.
         passthru: '/index.php'
 
-        # Allow 90M files to be uploaded.
+        # Allow 300M files to be uploaded.
         request_buffering:
           enabled: true
-          max_request_size: 100m
+          max_request_size: 320m
 
         # Deny access to all static files, except those specifically allowed below.
         allow: false

--- a/config/sync/field.field.media.image.field_media_image.yml
+++ b/config/sync/field.field.media.image.field_media_image.yml
@@ -22,7 +22,7 @@ settings:
   handler_settings: {  }
   file_directory: '[date:custom:Y]-[date:custom:m]'
   file_extensions: 'png gif jpg jpeg svg webp'
-  max_filesize: ''
+  max_filesize: '100 MB'
   max_resolution: ''
   min_resolution: ''
   alt_field: true

--- a/config/sync/field.field.media.pdf.field_media_file.yml
+++ b/config/sync/field.field.media.pdf.field_media_file.yml
@@ -22,6 +22,6 @@ settings:
   handler_settings: {  }
   file_directory: '[date:custom:Y]-[date:custom:m]'
   file_extensions: pdf
-  max_filesize: ''
+  max_filesize: '100 MB'
   description_field: true
 field_type: file

--- a/config/sync/field.field.media.video.field_media_video_file.yml
+++ b/config/sync/field.field.media.video.field_media_video_file.yml
@@ -22,6 +22,6 @@ settings:
   handler_settings: {  }
   file_directory: '[date:custom:Y]-[date:custom:m]'
   file_extensions: 'mp4 webm'
-  max_filesize: ''
+  max_filesize: '300 MB'
   description_field: false
 field_type: file

--- a/lando-config/php.ini
+++ b/lando-config/php.ini
@@ -3,3 +3,5 @@
 ; only critical errors and suppresses these connection errors.
 ; https://xdebug.org/docs/all_settings#XDEBUG_CONFIG
 ;xdebug.log_level=0
+post_max_size=300M
+upload_max_filesize=300M

--- a/orch/deploy_install.sh
+++ b/orch/deploy_install.sh
@@ -1,7 +1,5 @@
 #!/usr/bin/env bash
 
-set -e
-
 ./orch/show_file.sh $0
 
 # Normally, XDEBUG_MODE=debug,develop but develop breaks the Drupal installation.
@@ -11,6 +9,8 @@ if [ -n "$XDEBUG_MODE" ]; then
 fi
 
 drush cr
+
+set -e
 
 # If using Postgres, enable the pg_trgm extension which is required before
 # Drupal is installed.

--- a/web/sites/default/settings.memcache.php
+++ b/web/sites/default/settings.memcache.php
@@ -5,7 +5,8 @@ use Drupal\Core\Installer\InstallerKernel;
 if ((
   !InstallerKernel::installationAttempted() &&
   (extension_loaded('memcached') || extension_loaded('memcache')) &&
-  file_exists($app_root . '/modules/contrib/memcache')
+  file_exists($app_root . '/modules/contrib/memcache') &&
+  !function_exists('_settings_memcache')
 )) {
   function _settings_memcache(array &$settings, string $host): void {
     $settings['memcache']['servers'][$host] = 'default';

--- a/web/sites/default/settings.redis.php
+++ b/web/sites/default/settings.redis.php
@@ -5,7 +5,8 @@ use Drupal\Core\Installer\InstallerKernel;
 if ((
   !InstallerKernel::installationAttempted() &&
   extension_loaded('redis') &&
-  class_exists('Drupal\redis\ClientFactory')
+  class_exists('Drupal\redis\ClientFactory') &&
+  !function_exists('_settings_redis')
 )) {
   function _settings_redis(array &$settings, string $host, string $port): void {
     $settings['redis.connection']['host'] = $host;


### PR DESCRIPTION
Image & PDF 100 MB: /admin/structure/media/manage/image/fields/media.image.field_media_image, /admin/structure/media/manage/pdf/fields/media.pdf.field_media_file
Video 300 MB: /admin/structure/media/manage/video/fields/media.video.field_media_video_file

/admin/reports/status/php post_max_size & upload_max_filesize 300M

Lando & https://feature-bsd-318-file-236uqiq-tsvj5tw7p3f66.us.platformsh.site/ should be identical.