### PR TITLE
BSD fixes #329: Create initial alert component

### DIFF
--- a/.lando.dist.yml
+++ b/.lando.dist.yml
@@ -46,6 +46,7 @@ tooling:
       - 'drush default-content:export-references menu_link_content --folder=modules/custom/bixal_default_content/content'
       - 'drush default-content:export-references media --folder=modules/custom/bixal_default_content/content'
       - 'drush default-content:export-references config_pages --folder=modules/custom/bixal_default_content/content'
+      - 'drush default-content:export-references sitewide_alert --folder=modules/custom/bixal_default_content/content'
   patch:
     service: appserver
     description: Apply composer patches or regenerate lock hash.

--- a/config/sync/core.entity_form_display.sitewide_alert.sitewide_alert.default.yml
+++ b/config/sync/core.entity_form_display.sitewide_alert.sitewide_alert.default.yml
@@ -25,13 +25,6 @@ content:
     third_party_settings: {  }
   field_no_icon:
     type: boolean_checkbox
-    weight: 3
-    region: content
-    settings:
-      display_label: true
-    third_party_settings: {  }
-  field_slim:
-    type: boolean_checkbox
     weight: 2
     region: content
     settings:
@@ -46,5 +39,6 @@ content:
       placeholder: ''
     third_party_settings: {  }
 hidden:
+  field_slim: true
   langcode: true
   user_id: true

--- a/config/sync/sitewide_alert.settings.yml
+++ b/config/sync/sitewide_alert.settings.yml
@@ -1,7 +1,7 @@
 _core:
   default_config_hash: 0y_QHS2RsEHVusPnhiEqDUshLy8-YqDaXtafZJdYjXA
 show_on_admin: 0
-alert_styles: "info|Info\r\nemergency|Emergency"
+alert_styles: "info|Info\r\nwarning|Warning\r\nurgent|Urgent"
 display_order: ascending
 refresh_interval: 15
 automatic_refresh: 0

--- a/config/sync/user.role.site_admin.yml
+++ b/config/sync/user.role.site_admin.yml
@@ -14,6 +14,7 @@ dependencies:
     - recaptcha
     - redirect
     - role_delegation
+    - sitewide_alert
     - system
     - toolbar
 id: site_admin
@@ -23,6 +24,7 @@ is_admin: null
 permissions:
   - 'access administration pages'
   - 'access toolbar'
+  - 'add sitewide alert entities'
   - 'administer CAPTCHA settings'
   - 'administer contact forms'
   - 'administer cookies services and service groups'
@@ -37,6 +39,8 @@ permissions:
   - 'configure cookies config'
   - 'configure cookies widget texts'
   - 'create url aliases'
+  - 'delete sitewide alert entities'
   - 'edit accreditations config page entity'
+  - 'edit sitewide alert entities'
   - 'use admin toolbar search'
   - 'view the administration theme'

--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
     "start": "npm run storybook",
     "storybook": "storybook dev -p 80",
     "storybook:local": "storybook dev -p 5050",
-    "build-storybook": "storybook build"
+    "build-storybook": "storybook build",
+    "static-sb": "npm run build-storybook && npx http-server storybook-static/"
   },
   "repository": {
     "type": "git",

--- a/stories/_index.scss
+++ b/stories/_index.scss
@@ -1,4 +1,5 @@
 // Add any custom component files here using @forward.
+@forward "components/alert/alert";
 @forward "components/blurb/blurb";
 @forward "components/button/button";
 @forward "components/cards/cards";
@@ -12,6 +13,7 @@
 @forward "components/people-list/people-list";
 @forward "components/profile/profile";
 @forward "components/section/section";
+@forward "components/site-alert/site-alert";
 @forward "components/social-nav/social-nav";
 @forward "assets/styles/global/global";
 

--- a/stories/assets/styles/global/global.scss
+++ b/stories/assets/styles/global/global.scss
@@ -42,7 +42,10 @@ $font-heading: "novel-pro", Georgia, Times, "Times New Roman", serif;
 // Modern normalize - CSS Reset.
 @import url("https://cdnjs.cloudflare.com/ajax/libs/modern-normalize/2.0.0/modern-normalize.min.css");
 
-// Proxima Nova and Novel pro typefaces.
+// Typefaces:
+// Proxima Nova (400, 600, 700)
+// Novel pro (700 & 800)
+// poynter-gothic-text (400, 400 italic, 700, 700 italic)
 @import url("https://use.typekit.net/wfu7yyr.css");
 
 // ==========================================================================

--- a/stories/assets/styles/global/global.scss
+++ b/stories/assets/styles/global/global.scss
@@ -34,6 +34,10 @@ $font-heading: "novel-pro", Georgia, Times, "Times New Roman", serif;
   --c-info-darker: #{color("blue-cool-30v")};
   // Warning
   --c-warning: #{$c-yellow};
+  // Error
+  --c-error: #{color("orange-warm-50v")};
+  // Urgent
+  --c-urgent: #{color("orange-warm-70v")};
   // Fonts
   --font-heading: #{$font-heading};
   --font-ui: #{$font-ui};

--- a/stories/assets/styles/global/global.scss
+++ b/stories/assets/styles/global/global.scss
@@ -9,6 +9,7 @@ $c-purple: #7d0096;
 $c-green: #deec1c;
 $c-maroon: #55052a;
 $c-orange: #fda307;
+$c-yellow: color("yellow-20v");
 $c-red-orange: #e02f00;
 $c-gray: color("gray-4");
 
@@ -16,6 +17,7 @@ $font-ui: "proxima-nova", "Proxima Nova", Arial, Helvetica, sans-serif;
 $font-heading: "novel-pro", Georgia, Times, "Times New Roman", serif;
 
 :root {
+  // Theme colors
   --c-primary: #{$c-blue--dark};
   --c-primary-alt: #{$c-purple};
   --c-accent-cool: #{$c-blue--light};
@@ -25,6 +27,14 @@ $font-heading: "novel-pro", Georgia, Times, "Times New Roman", serif;
   --c-accent-warm-dark: #{$c-maroon};
   --c-accent-vivid: #{$c-green};
   --c-base: #{$c-gray};
+  // State colors
+  // Info - Closest USWDS color is blue-cool-10v.
+  --c-info: var(--c-accent-cool);
+  --c-info-dark: #{color("blue-cool-20v")};
+  --c-info-darker: #{color("blue-cool-30v")};
+  // Warning
+  --c-warning: #{$c-yellow};
+  // Fonts
   --font-heading: #{$font-heading};
   --font-ui: #{$font-ui};
 }

--- a/stories/assets/styles/utils/mixins/_alert-base-styles.scss
+++ b/stories/assets/styles/utils/mixins/_alert-base-styles.scss
@@ -1,0 +1,33 @@
+@use "uswds-core" as *;
+
+/// Applies shared base styles to alert and site alert components.
+///
+/// @example
+/// .bix-alert {
+///   @include alert-base-styles;
+/// }
+///
+/// This mixin assumes the following structure:
+/// - `.alert__heading` contains the heading text.
+/// - `.alert__icon` contains the icon element.
+/// - `.alert__text` contains the main text content.
+@mixin alert-base-styles {
+  &__heading {
+    display: flex;
+    align-items: flex-start;
+    column-gap: units("05");
+    font-family: var(--font-ui);
+    font-weight: 600;
+    margin-top: 0;
+  }
+
+  &__icon {
+    display: inline-flex;
+    align-items: center;
+    margin-left: calc(#{units(-4)} + #{units("05")}); // Offset column gap.
+  }
+
+  &__text > :last-child {
+    margin-bottom: 0;
+  }
+}

--- a/stories/components/alert/alert.html.twig
+++ b/stories/components/alert/alert.html.twig
@@ -3,8 +3,10 @@
   * Alert component.
   *
   * Available variables:
-  * - title: Optional string for the alert header.
   * - variant: String alert type: info, error, warning.
+  * - icon: String alert icon from USWDS: info, error, warning.
+  * - heading_type: Optional string for the type of header (h1-h6).
+  * - title: Optional string for the alert header.
   * - text: A string of the alert body text.
 **/
 #}
@@ -23,8 +25,16 @@
 
 <div{{ attributes.addClass(alert_classes) }}>
   <div class="bix-alert__body">
+
+
   {% if title %}
     <{{ heading_type }} class="bix-alert__heading">
+    {% if icon %}
+    <span class="bix-alert__icon">
+      {{ source(icon) }}
+    </span>
+    {% endif %}
+
       {{ title }}
     </{{ heading_type }}>
   {% endif %}

--- a/stories/components/alert/alert.html.twig
+++ b/stories/components/alert/alert.html.twig
@@ -1,0 +1,37 @@
+{#
+/**
+  * Alert component.
+  *
+  * Available variables:
+  * - title: Optional string for the alert header.
+  * - variant: String alert type: info, error, warning.
+  * - text: A string of the alert body text.
+**/
+#}
+
+
+{% set heading_type = heading_type | default("h4") %}
+
+{% if attributes is empty %}
+  {% set attributes = create_attribute() %}
+{% endif %}
+
+{% set alert_classes = [
+  "bix-alert",
+  (variant ? "bix-alert--" ~ variant),
+] | merge(additional_classes | default([])) %}
+
+<div{{ attributes.addClass(alert_classes) }}>
+  <div class="bix-alert__body">
+  {% if title %}
+    <{{ heading_type }} class="bix-alert__heading">
+      {{ title }}
+    </{{ heading_type }}>
+  {% endif %}
+  {% if text %}
+    <div class="bix-alert__text">
+      {{ text }}
+    </div>
+  {% endif %}
+  </div>
+</div>

--- a/stories/components/alert/alert.scss
+++ b/stories/components/alert/alert.scss
@@ -1,0 +1,29 @@
+@use "uswds-core" as *;
+
+.bix-alert {
+  --_alert-color: var(--alert-color, currentColor);
+
+  border-left: 4px solid var(--_alert-color);
+
+  &__heading {
+    font-family: var(--font-ui);
+    font-weight: 600;
+    margin-top: 0;
+  }
+
+  &__body {
+    padding: units(1.5) units(2.5);
+  }
+
+  &__text > :last-child {
+    margin-bottom: 0;
+  }
+}
+
+.bix-alert--info {
+  --alert-color: var(--c-info-darker);
+}
+
+.bix-alert--warning {
+  --alert-color: var(--c-warning);
+}

--- a/stories/components/alert/alert.scss
+++ b/stories/components/alert/alert.scss
@@ -1,22 +1,16 @@
 @use "uswds-core" as *;
+@use "../../assets/styles/utils/mixins/alert-base-styles" as *;
 
 .bix-alert {
+  @include alert-base-styles;
+
   --_alert-color: var(--alert-color, currentColor);
 
   border-left: 4px solid var(--_alert-color);
 
-  &__heading {
-    font-family: var(--font-ui);
-    font-weight: 600;
-    margin-top: 0;
-  }
-
   &__body {
     padding: units(1.5) units(2.5);
-  }
-
-  &__text > :last-child {
-    margin-bottom: 0;
+    padding-left: units(5);
   }
 }
 
@@ -26,4 +20,8 @@
 
 .bix-alert--warning {
   --alert-color: var(--c-warning);
+}
+
+.bix-alert--error {
+  --alert-color: var(--c-error);
 }

--- a/stories/components/alert/alert.stories.js
+++ b/stories/components/alert/alert.stories.js
@@ -1,0 +1,46 @@
+import Alert from "./alert.html.twig";
+import "./alert.scss";
+
+export default {
+  title: "Components/Alert",
+  tags: ["autodocs"],
+  component: Alert,
+};
+
+const defaultContent = {
+  title: "Important Notice for Applicants",
+  text: `
+    <p>
+      At Bixal, we want to ensure a transparent and secure application process for all candidates. Please note that:
+    </p>
+    <ul>
+      <li>Our recruiters will never request sensitive personal information (such as social security numbers or banking information).</li>
+      <li>Our messages will never include requests to download applications or attachments.</li>
+      <li>Legitimate recruitment communications will always include clear contact details and may reference our public job postings.</li>
+    </ul>
+    <p>
+      If you experience any challenges with your submission or need assistance in completing your application for accessibility purposes, please reach out to us. <strong><a href="mailto:talent@bixal.com">We're here to help</a></strong>!
+    </p>
+  `,
+};
+
+export const Default = {
+  args: {
+    heading_type: null,
+    ...defaultContent,
+  },
+};
+
+export const Info = {
+  args: {
+    ...defaultContent,
+    variant: "info",
+  },
+};
+
+export const Warning = {
+  args: {
+    ...defaultContent,
+    variant: "warning",
+  },
+};

--- a/stories/components/site-alert/site-alert.html.twig
+++ b/stories/components/site-alert/site-alert.html.twig
@@ -1,0 +1,50 @@
+{#
+/**
+  * Site Alert component.
+  *
+  * Available variables:
+  * - variant: String alert type: info, error, warning.
+  * - icon: String for icon type.
+  * - aria_label: Optional string for the aria label, must be unique.
+  * - heading_type: Optional string for the type of header (h1-h6).
+  * - title: Optional string for the alert header.
+  * - text: A string of the alert body text.
+**/
+#}
+
+
+{% set heading_type = heading_type | default("h4") %}
+
+{% if attributes is empty %}
+  {% set attributes = create_attribute() %}
+{% endif %}
+
+{% set alert_classes = [
+  "bix-site-alert",
+  (variant ? "bix-site-alert--" ~ variant),
+] | merge(additional_classes | default([])) %}
+
+{# Must be unique if mulitple on page. #}
+{% set aria_label = ariaLabel | default("Site alert")  %}
+
+<section{{ attributes.addClass(alert_classes).setAttribute("aria-label", aria_label) }} >
+  <div class="bix-container">
+    <div class="bix-site-alert__body">
+    {% if title %}
+      <{{ heading_type }} class="bix-site-alert__heading">
+        {% if icon %}
+        <span class="bix-site-alert__icon">
+          {{ source(icon) }}
+        </span>
+        {% endif %}
+        {{ title }}
+      </{{ heading_type }}>
+    {% endif %}
+    {% if text %}
+      <div class="bix-site-alert__text">
+        {{ text }}
+      </div>
+    {% endif %}
+    </div>
+  </div>
+</section>

--- a/stories/components/site-alert/site-alert.scss
+++ b/stories/components/site-alert/site-alert.scss
@@ -1,0 +1,31 @@
+@use "uswds-core" as *;
+@use "../../assets/styles/utils/mixins/alert-base-styles" as *;
+
+.bix-site-alert {
+  @include alert-base-styles;
+
+  --_alert-color: var(--alert-color, var(--c-base));
+
+  background-color: var(--_alert-color);
+
+  &__icon svg {
+    fill: currentColor;
+  }
+
+  &__body {
+    padding: units(3) units(2.5);
+  }
+}
+
+.bix-site-alert--info {
+  --alert-color: var(--c-info);
+}
+
+.bix-site-alert--warning {
+  --alert-color: var(--c-warning);
+}
+
+.bix-site-alert--urgent {
+  --alert-color: var(--c-urgent);
+  color: color("white");
+}

--- a/stories/components/site-alert/site-alert.stories.js
+++ b/stories/components/site-alert/site-alert.stories.js
@@ -1,13 +1,14 @@
-import Alert from "./alert.html.twig";
-import "./alert.scss";
+import SiteAlert from "./site-alert.html.twig";
+import "./site-alert.scss";
+
 import infoIcon from "@uswds/uswds/img/usa-icons/info_outline.svg";
 import warningIcon from "@uswds/uswds/img/usa-icons/warning.svg";
 import errorIcon from "@uswds/uswds/img/usa-icons/error_outline.svg";
 
 export default {
-  title: "Components/Alert",
+  title: "Components/Site Alert",
   tags: ["autodocs"],
-  component: Alert,
+  component: SiteAlert,
 };
 
 const defaultContent = {
@@ -50,10 +51,10 @@ export const Warning = {
   },
 };
 
-export const Error = {
+export const Urgent = {
   args: {
     ...defaultContent,
     icon: errorIcon,
-    variant: "error",
+    variant: "urgent",
   },
 };

--- a/web/modules/custom/bixal_default_content/content/sitewide_alert/d5ff2381-ddfc-44b1-93cd-627d79bd662f.yml
+++ b/web/modules/custom/bixal_default_content/content/sitewide_alert/d5ff2381-ddfc-44b1-93cd-627d79bd662f.yml
@@ -1,0 +1,52 @@
+_meta:
+  version: '1.0'
+  entity_type: sitewide_alert
+  uuid: d5ff2381-ddfc-44b1-93cd-627d79bd662f
+  default_langcode: en
+default:
+  revision_user:
+    -
+      target_id: 1
+  status:
+    -
+      value: true
+  user_id:
+    -
+      target_id: 1
+  name:
+    -
+      value: 'Lever Issue'
+  style:
+    -
+      value: urgent
+  dismissible:
+    -
+      value: false
+  dismissible_ignore_before_time:
+    -
+      value: 0
+  limit_to_pages:
+    -
+      value: /careers
+  limit_to_pages_negate:
+    -
+      value: false
+  message:
+    -
+      value: '<p>At Bixal, we want to ensure a transparent and secure application process for all candidates. Please note that:</p><ul><li>Our recruiters will never request sensitive personal information (such as social security numbers or banking information).</li><li>Our messages will never include requests to download applications or attachments.</li><li>Legitimate recruitment communications will always include clear contact details and may reference our public job postings.</li></ul><p>If you experience any challenges with your submission or need assistance in completing your application for accessibility purposes, please reach out to us. <a href="mailto:talent@bixal.com"><strong>We''re here to help</strong></a><strong>!</strong></p>'
+      format: html_text
+  scheduled_alert:
+    -
+      value: false
+  created:
+    -
+      value: 1730490973
+  field_heading:
+    -
+      value: 'Important Notice for Applicants'
+  field_no_icon:
+    -
+      value: false
+  field_slim:
+    -
+      value: false

--- a/web/themes/custom/bixal_uswds/templates/content/sitewide-alert.html.twig
+++ b/web/themes/custom/bixal_uswds/templates/content/sitewide-alert.html.twig
@@ -23,25 +23,20 @@
 #}
 {% if heading or content %}
     <div {{ attributes }}>
-        <section class="usa-site-alert usa-site-alert--{{ style }}{% if slim  %} usa-site-alert--slim{% endif %}{% if no_icon  %} usa-site-alert--no-icon{% endif %}" aria-label="Site alert,">
-            <div class="usa-alert">
-                <div class="usa-alert__body">
-                    {% if heading -%}
-                        <h4 class="usa-alert__heading">{{ heading }}</h4>
-                    {%- endif %}
-                    {% if content -%}
-                        <div class="usa-alert__text">
-                            {{- content -}}
-                            {% if is_dismissible -%}
-                                {# The dismiss (close) button must have the class js-dismiss-button in order to work. #}
-                                <button class="close js-dismiss-button" aria-label="{{ 'close'|t }}">
-                                    <span aria-hidden="true">×</span>
-                                </button>
-                            {%- endif %}
-                        </div>
-                    {%- endif %}
-                </div>
-            </div>
-        </section>
+        {% if not no_icon  %}
+             {% if style == 'urgent' %}
+                {% set icon = directory ~ '/dist/assets/img/usa-icons/error_outline.svg' %}
+             {% elseif style == 'warning' %}
+                {% set icon = directory ~ '/dist/assets/img/usa-icons/warning.svg' %}
+             {% else %}
+                {% set icon = directory ~ '/dist/assets/img/usa-icons/info_outline.svg' %}
+             {% endif %}
+        {% endif %}
+        {% include '@components/site-alert/site-alert.html.twig' with {
+            'title': heading,
+            'text': content,
+            'variant': style,
+            'icon': icon,
+        } %}
     </div>
 {% endif %}


### PR DESCRIPTION
Two new alert components with variants. Based on USWDS guidance. Closes #329.

1. **Alert**. An inline alert that can be used for form messages. Includes variants for: info, warning, and error.
2. **Site alert**. Full width alerts that go at the top of the page and span the entire width. Use these for alerts that are important for users to see first. Do **not** use this for form error handling (use alert instead).

## Alert

**Base**
![image](https://github.com/user-attachments/assets/67b03728-4a57-4c93-8b84-92e53cc6d3bf)

**Info**
![image](https://github.com/user-attachments/assets/534e8d2d-3dcf-41ee-b4e1-1722eceea66a)

**Warning**
![image](https://github.com/user-attachments/assets/1f0c7859-f252-45c7-8260-a89c49c6040f)

**Error**
![image](https://github.com/user-attachments/assets/cb839d3c-e600-4fee-bb53-d10275220bce)

## Site alert

**Base**
![image](https://github.com/user-attachments/assets/deefb35f-c9e6-4cd6-8bc1-17cdaca0ea6a)

**Info**
![image](https://github.com/user-attachments/assets/9aa970b5-af36-4d6c-a964-78d097219f30)

**Warning**
![image](https://github.com/user-attachments/assets/31399a42-29bd-424d-9e48-7d09a1965f14)

**Urgent** for urgent, time sensitive notifications.
![image](https://github.com/user-attachments/assets/16b591d5-6b95-4d90-a9bd-bc01603c20dc)


