### PR TITLE
BSD-336: Add case study node template

### DIFF
--- a/stories/components/section/section.html.twig
+++ b/stories/components/section/section.html.twig
@@ -22,10 +22,8 @@
   (center_content ? "bix-section--center-content"),
 ] | merge(additional_classes | default([])) %}
 
-{% set heading_type = heading_type | default("h2") %}
-
 <section
-  {{ attributes.addClass(section_classes) }} {% if image %} style="background-image: url('{{ image }}')" {% endif %}>
+    {{ attributes.addClass(section_classes) }} {% if image %} style="background-image: url('{{ image }}')" {% endif %}>
 
   {#
     /**
@@ -40,12 +38,7 @@
           {{ prefix }}
         </div>
       {% endif %}
-
-      {% if title %}
-        <{{heading_type}} class="bix-section__title">
-          {{ title }}
-        </{{heading_type}}>
-      {% endif %}
+      {% include "@partials/section-title.html.twig" %}
     {% endblock %}
 
     {% block description %}
@@ -61,7 +54,7 @@
     {% block footer %}
       {% if cta.label %}
         <div
-          class="bix-section__footer">
+            class="bix-section__footer">
           {# Avoid button inheriting section data. #}
           {% include "@components/button/button.html.twig" with cta only %}
         </div>

--- a/stories/partials/section-title.html.twig
+++ b/stories/partials/section-title.html.twig
@@ -1,0 +1,20 @@
+{#
+/**
+ * @file
+ * Allows using the title element from a section anywhere.
+ *
+ * Example:
+{% include "@partials/section-title.html.twig" with {
+  heading_type: 'h2'
+  title: 'A great title',
+} %}
+ * Available variables:
+ * - heading_type (string): The URL of the image.
+ * - title (string): The title to display.
+ #}
+{% if title %}
+    {% set heading_type = heading_type | default("h2") %}
+    <{{heading_type}} class="bix-section__title">
+        {{ title }}
+    </{{heading_type}}>
+{% endif %}

--- a/stories/partials/section-title.html.twig
+++ b/stories/partials/section-title.html.twig
@@ -11,7 +11,7 @@
  * Available variables:
  * - heading_type (string): The URL of the image.
  * - title (string): The title to display.
- #}
+#}
 {% if title %}
     {% set heading_type = heading_type | default("h2") %}
     <{{heading_type}} class="bix-section__title">

--- a/web/modules/custom/bixal_default_content/content/node/49da5723-5914-4252-a7aa-c27d3efd8fb3.yml
+++ b/web/modules/custom/bixal_default_content/content/node/49da5723-5914-4252-a7aa-c27d3efd8fb3.yml
@@ -1,0 +1,56 @@
+_meta:
+  version: '1.0'
+  entity_type: node
+  uuid: 49da5723-5914-4252-a7aa-c27d3efd8fb3
+  bundle: case_study
+  default_langcode: en
+default:
+  revision_uid:
+    -
+      target_id: 1
+  status:
+    -
+      value: true
+  uid:
+    -
+      target_id: 1
+  title:
+    -
+      value: 'Building cybersecurity capacity of civil society organizations in Colombia to improve digital health and protect against cyber threats.'
+  created:
+    -
+      value: 1730993228
+  promote:
+    -
+      value: false
+  sticky:
+    -
+      value: false
+  path:
+    -
+      alias: /our-work/digital-apex
+      langcode: en
+      pathauto: 0
+  field_challenge:
+    -
+      value: '<p>The increased use of technology, mobile phones and digital systems means USAID/Colombia’s IPs face a wide range of vulnerabilities, such as phishing attacks, account impersonation attempts and cyber-based corrupt financial transactions. The scarcity of cybersecurity education for vulnerable IPs translates to a higher risk of attacks and security breaches, which forces organizations to remedy system failures and change user behaviors to mitigate future attacks. Attacks can erode the public’s and stakeholders’ trust in how organizations handle personal and sensitive information, ultimately undermining IPs’ integrity and confidence in the programs they deploy.</p>'
+      format: html_text
+  field_client:
+    -
+      value: 'United States Agency for International Development (USAID)'
+  field_conclusion:
+    -
+      value: '<p>Bixal applied an Agile learning approach in designing and developing a cybersecurity training program to help USAID IPs and civil society organizations in Colombia improve their digital health, build local capacity and strengthen cybersecurity practices. As part of this program, Bixal provided access to asynchronous training modules and delivered 15 synchronous virtual ILT sessions to over 298 participants from 44 USAID partners. The topics selected contributed to a growing knowledge base on cybersecurity vulnerabilities that impact organizations’ governance structure, technology infrastructure and business operations.</p><p>Working with the USAID/Colombia Mission, Bixal assessed existing hardware and software assets for cybersecurity vulnerabilities and delivered training organized into five learning topics that mapped to 20 CIS controls.</p><p>In Bixal’s experience, when people understand cybersecurity threats and demonstrate familiarity with best practices to combat cyberattacks, the likelihood of destructive cyberattacks decreases.</p><p>Webinar quiz results demonstrated that USAID/Colombia’s IPs had a low baseline knowledge of cybersecurity. Data from the 10 risk assessments conducted in Phase II confirmed the need for cybersecurity action plans. Over 95 percent of participants who identified as “novice” before the training advanced their knowledge to align with higher competency levels as a result of the program. Detailed post-training survey results are captured in the following chart.</p><p>Overall, Bixal delivered cybersecurity training to 298 individuals, supporting capacity development for 44 organizations to improve their digital health.</p>'
+      format: html_text
+  field_impact:
+    -
+      value: '<p>Through a combined approach of asynchronous training and virtual learning, 298 individuals representing 44 organizations in Colombia increased their knowledge of cybersecurity and improved their digital health practices. Bixal conducted cyber risk assessments with the most vulnerable partner organizations to develop roadmaps with action items designed to increase digital protection and reduce the risk of cyberattacks.</p>'
+      format: html_text
+  field_introduction:
+    -
+      value: '<p>Under Digital APEX — implemented by prime contractor Project Management Consulting Group (PMCG) — Bixal collaborated with the USAID/Colombia Mission to develop and implement the Cybersecurity Integration of Partners and Hacking Emergency Response (CIPHER), a cybersecurity training program that uses an easily replicable three-phased approach.</p>'
+      format: html_text
+  field_solution:
+    -
+      value: '<p>Working with the USAID/Colombia Mission, Bixal developed and implemented a cybersecurity training program that used an interactive online training format, assessed existing hardware and software assets, and developed action plans aligned to best practices outlined in the Center for Internet Security (CIS) Controls to improve cybersecurity vulnerabilities.</p>'
+      format: html_text

--- a/web/themes/custom/bixal_uswds/templates/node/node--case-study--full.html.twig
+++ b/web/themes/custom/bixal_uswds/templates/node/node--case-study--full.html.twig
@@ -1,0 +1,105 @@
+{#
+/**
+* @file
+* Theme override to display a node.
+*
+* Available variables:
+* - node: The node entity with limited access to object properties and methods.
+* Only method names starting with "get", "has", or "is" and a few common
+* methods such as "id", "label", and "bundle" are available. For example:
+* - node.getCreatedTime() will return the node creation timestamp.
+* - node.hasField('field_example') returns TRUE if the node bundle includes
+* field_example. (This does not indicate the presence of a value in this
+* field.)
+* - node.isPublished() will return whether the node is published or not.
+* Calling other methods, such as node.delete(), will result in an exception.
+* See \Drupal\node\Entity\Node for a full list of public properties and
+* methods for the node object.
+* - label: (optional) The title of the node.
+* - content: All node items. Use {{ content }} to print them all,
+* or print a subset such as {{ content.field_example }}. Use
+* {{ content|without('field_example') }} to temporarily suppress the printing
+* of a given child element.
+* - author_picture: The node author user entity, rendered using the "compact"
+* view mode.
+* - metadata: Metadata for this node.
+* - date: (optional) Themed creation date field.
+* - author_name: (optional) Themed author name field.
+* - url: Direct URL of the current node.
+* - display_submitted: Whether submission information should be displayed.
+* - attributes: HTML attributes for the containing element.
+* The attributes.class element may contain one or more of the following
+* classes:
+* - node: The current template type (also known as a "theming hook").
+* - node--type-[type]: The current node type. For example, if the node is an
+* "Article" it would result in "node--type-article". Note that the machine
+* name will often be in a short form of the human readable label.
+* - node--view-mode-[view_mode]: The View Mode of the node; for example, a
+* teaser would result in: "node--view-mode-teaser", and
+* full: "node--view-mode-full".
+* The following are controlled through the node publishing options.
+* - node--promoted: Appears on nodes promoted to the front page.
+* - node--sticky: Appears on nodes ordered above other non-sticky nodes in
+* teaser listings.
+* - node--unpublished: Appears on unpublished nodes visible only to site
+* admins.
+* - title_attributes: Same as attributes, except applied to the main title
+* tag that appears in the template.
+* - content_attributes: Same as attributes, except applied to the main
+* content tag that appears in the template.
+* - author_attributes: Same as attributes, except applied to the author of
+* the node tag that appears in the template.
+* - title_prefix: Additional output populated by modules, intended to be
+* displayed in front of the main title tag that appears in the template.
+* - title_suffix: Additional output populated by modules, intended to be
+* displayed after the main title tag that appears in the template.
+* - view_mode: View mode; for example, "teaser" or "full".
+* - teaser: Flag for the teaser state. Will be true if view_mode is 'teaser'.
+* - page: Flag for the full page state. Will be true if view_mode is 'full'.
+* - readmore: Flag for more state. Will be true if the teaser content of the
+* node cannot hold the main body content.
+* - logged_in: Flag for authenticated user status. Will be true when the
+* current user is a logged-in member.
+* - is_admin: Flag for admin user status. Will be true when the current user
+* is an administrator.
+*
+* @see template_preprocess_node()
+*
+*/
+#}
+
+{% include "@components/section/section.html.twig" with {
+    variant: "primary-alt",
+    heading_type: "h1",
+    prefix: content.field_client | field_value,
+    title: node.label,
+} only %}
+
+{% set main_body %}
+  {{ content.field_introduction | field_value }}
+  {% include "@partials/section-title.html.twig" with {
+    title: 'Challenge' | t,
+  } only %}
+  {{ content.field_challenge | field_value }}
+  {% include "@partials/section-title.html.twig" with {
+    title: 'Solution' | t,
+  } only %}
+  {{ content.field_solution | field_value }}
+{% endset %}
+
+{% include "@components/section/section.html.twig" with {
+    title: 'Introduction' | t,
+    body: main_body
+} only %}
+
+{% include "@components/section/section.html.twig" with {
+    variant: "accent-cool",
+    title: 'Impact' | t,
+    body: content.field_introduction | field_value
+} only %}
+
+{% include "@components/section/section.html.twig" with {
+    variant: "primary-alt",
+    title: 'Conclusion' | t,
+    body: content.field_introduction | field_value
+} only %}


### PR DESCRIPTION
Creates a node template for the case study content type and exports a single case study so it can be easily reviewed at /our-work/digital-apex.

Testing:
`lando si` then visit the above link.