### PR TITLE
BSD fixes #338: Allow cache to be cleared with Drush again.

### DIFF
--- a/web/sites/default/settings.lando.php
+++ b/web/sites/default/settings.lando.php
@@ -47,21 +47,22 @@ if (isset($lando_info->database)) {
 if (isset($lando_info->cache->type)) {
   switch ($lando_info->cache->type) {
     case 'redis':
-      require 'settings.redis.php';
-      if (function_exists('_settings_redis')) {
-        _settings_redis(
+      require_once 'settings.redis.php';
+      if (function_exists('_drupal_env_settings_redis')) {
+        _drupal_env_settings_redis(
           $settings,
           $lando_info->cache->internal_connection->host,
-          $lando_info->cache->internal_connection->port
+          $lando_info->cache->internal_connection->port,
+          'PhpRedis',
         );
       }
       break;
 
     case 'memcached':
-      require 'settings.memcache.php';
-      if (function_exists('_settings_memcache')) {
-        $memcache_host = implode(':', (array)$lando_info->cache->internal_connection);
-        _settings_memcache($settings, $memcache_host);
+      require_once 'settings.memcache.php';
+      if (function_exists('_drupal_env_settings_memcache')) {
+        $memcache_host = implode(':', (array) $lando_info->cache->internal_connection);
+        _drupal_env_settings_memcache($settings, $memcache_host);
       }
       break;
 

--- a/web/sites/default/settings.memcache.php
+++ b/web/sites/default/settings.memcache.php
@@ -2,27 +2,37 @@
 
 use Drupal\Core\Installer\InstallerKernel;
 
-if ((
+if (
   !InstallerKernel::installationAttempted() &&
   (extension_loaded('memcached') || extension_loaded('memcache')) &&
-  file_exists($app_root . '/modules/contrib/memcache') &&
-  !function_exists('_settings_memcache')
-)) {
-  // These settings need to be applied multiple times, depending on how often
-  // initialize is called, they need to be reapplied every time.
-  function _settings_memcache(array &$settings, string $host): void {
+  file_exists($app_root . '/modules/contrib/memcache')
+) {
+  /**
+   * Apply Memcache cache settings.
+   *
+   * Drush can be bootstrap Drupal twice, this should be safe to be called
+   * multiple times.
+   *
+   * @param array $settings
+   *   The $settings array from settings.php.
+   * @param string $host
+   *   The host that Memcache will be contacted on.
+   *
+   * @return void
+   */
+  function _drupal_env_settings_memcache(array &$settings, string $host): void {
     $settings['memcache']['servers'][$host] = 'default';
 
-    # Use for all bins otherwise specified.
+    // Use for all bins otherwise specified.
     $settings['cache']['default'] = 'cache.backend.memcache';
 
-    // Optional settings:
+    /* Optional settings:
 
-    // Apply changes to the container configuration to better leverage Memcache.
-    // This includes using Memcache for the lock and flood control systems, as well
-    // as the cache tag checksum. Alternatively, copy the contents of that file
-    // to your project-specific services.yml file, modify as appropriate, and
-    // remove this line.
+    Apply changes to the container configuration to better leverage Memcache.
+    This includes using Memcache for the lock and flood control systems, as well
+    as the cache tag checksum. Alternatively, copy the contents of that file
+    to your project-specific services.yml file, modify as appropriate, and
+    remove this line. */
     $settings['container_yamls'][] = 'modules/contrib/memcache/example.services.yml';
 
     // Allow the services to work before the Memcache module itself is enabled.
@@ -37,7 +47,6 @@ if ((
   }
 
   // These only need to be done once, then they are included and applied always.
-
   // Manually add the classloader path, this is required for the container cache bin definition below
   // and allows to use it without the Memcache module being enabled.
   $class_loader->addPsr4('Drupal\\memcache\\', 'modules/contrib/memcache/src');

--- a/web/sites/default/settings.memcache.php
+++ b/web/sites/default/settings.memcache.php
@@ -8,35 +8,37 @@ if ((
   file_exists($app_root . '/modules/contrib/memcache') &&
   !function_exists('_settings_memcache')
 )) {
+  // These settings need to be applied multiple times, depending on how often
+  // initialize is called, they need to be reapplied every time.
   function _settings_memcache(array &$settings, string $host): void {
     $settings['memcache']['servers'][$host] = 'default';
+
+    # Use for all bins otherwise specified.
+    $settings['cache']['default'] = 'cache.backend.memcache';
+
+    // Optional settings:
+
+    // Apply changes to the container configuration to better leverage Memcache.
+    // This includes using Memcache for the lock and flood control systems, as well
+    // as the cache tag checksum. Alternatively, copy the contents of that file
+    // to your project-specific services.yml file, modify as appropriate, and
+    // remove this line.
+    $settings['container_yamls'][] = 'modules/contrib/memcache/example.services.yml';
+
+    // Allow the services to work before the Memcache module itself is enabled.
+    $settings['container_yamls'][] = 'modules/contrib/memcache/memcache.services.yml';
+
+    // Use Memcache for container cache.
+    // The container cache is used to load the container definition itself, and
+    // thus any configuration stored in the container itself is not available
+    // yet. These lines force the container cache to use Memcache rather than the
+    // default SQL cache.
+    require 'settings.memcache.container_pure.php';
   }
 
-  # Use for all bins otherwise specified.
-  $settings['cache']['default'] = 'cache.backend.memcache';
-
-  // Optional settings:
-
-  // Apply changes to the container configuration to better leverage Redis.
-  // This includes using Memcache for the lock and flood control systems, as well
-  // as the cache tag checksum. Alternatively, copy the contents of that file
-  // to your project-specific services.yml file, modify as appropriate, and
-  // remove this line.
-  $settings['container_yamls'][] = 'modules/contrib/memcache/example.services.yml';
-
-  // Allow the services to work before the Redis module itself is enabled.
-  $settings['container_yamls'][] = 'modules/contrib/memcache/memcache.services.yml';
+  // These only need to be done once, then they are included and applied always.
 
   // Manually add the classloader path, this is required for the container cache bin definition below
-  // and allows to use it without the redis module being enabled.
+  // and allows to use it without the Memcache module being enabled.
   $class_loader->addPsr4('Drupal\\memcache\\', 'modules/contrib/memcache/src');
-
-  require 'settings.memcache.container_pure.php';
 }
-
-
-
-
-
-
-

--- a/web/sites/default/settings.platformsh.php
+++ b/web/sites/default/settings.platformsh.php
@@ -42,57 +42,28 @@ if (isset($platformsh->branch)) {
 }
 
 // Enable Redis caching.
-if ($platformsh->hasRelationship('redis') && !InstallerKernel::installationAttempted() && extension_loaded('redis') && class_exists('Drupal\redis\ClientFactory')) {
-  $redis = $platformsh->credentials('redis');
-
-  // Set Redis as the default backend for any cache bin not otherwise specified.
-  $settings['cache']['default'] = 'cache.backend.redis';
-  $settings['redis.connection']['host'] = $redis['host'];
-  $settings['redis.connection']['port'] = $redis['port'];
-
-  // Apply changes to the container configuration to better leverage Redis.
-  // This includes using Redis for the lock and flood control systems, as well
-  // as the cache tag checksum. Alternatively, copy the contents of that file
-  // to your project-specific services.yml file, modify as appropriate, and
-  // remove this line.
-  $settings['container_yamls'][] = 'modules/contrib/redis/example.services.yml';
-
-  // Allow the services to work before the Redis module itself is enabled.
-  $settings['container_yamls'][] = 'modules/contrib/redis/redis.services.yml';
-
-  // Manually add the classloader path, this is required for the container cache bin definition below
-  // and allows to use it without the redis module being enabled.
-  $class_loader->addPsr4('Drupal\\redis\\', 'modules/contrib/redis/src');
-
-  // Use redis for container cache.
-  // The container cache is used to load the container definition itself, and
-  // thus any configuration stored in the container itself is not available
-  // yet. These lines force the container cache to use Redis rather than the
-  // default SQL cache.
-  $settings['bootstrap_container_definition'] = [
-    'parameters' => [],
-    'services' => [
-      'redis.factory' => [
-        'class' => 'Drupal\redis\ClientFactory',
-      ],
-      'cache.backend.redis' => [
-        'class' => 'Drupal\redis\Cache\CacheBackendFactory',
-        'arguments' => ['@redis.factory', '@cache_tags_provider.container', '@serialization.phpserialize'],
-      ],
-      'cache.container' => [
-        'class' => '\Drupal\redis\Cache\PhpRedis',
-        'factory' => ['@cache.backend.redis', 'get'],
-        'arguments' => ['container'],
-      ],
-      'cache_tags_provider.container' => [
-        'class' => 'Drupal\redis\Cache\RedisCacheTagsChecksum',
-        'arguments' => ['@redis.factory'],
-      ],
-      'serialization.phpserialize' => [
-        'class' => 'Drupal\Component\Serialization\PhpSerialize',
-      ],
-    ],
-  ];
+if ($platformsh->hasRelationship('redis')) {
+  require_once 'settings.redis.php';
+  if (function_exists('_drupal_env_settings_redis')) {
+    $redis = $platformsh->credentials('redis');
+    _drupal_env_settings_redis(
+      $settings,
+      $redis['host'],
+      $redis['port'],
+      'PhpRedis',
+    );
+  }
+}
+// Enable Memcached caching.
+if ($platformsh->hasRelationship('memcached')) {
+  require_once 'settings.memcache.php';
+  if (function_exists('_drupal_env_settings_memcache')) {
+    $memcached = $platformsh->credentials('memcached');
+    _drupal_env_settings_memcache(
+      $settings,
+    $memcached['host'] . ':' . $memcached['port']
+    );
+  }
 }
 
 if ($platformsh->inRuntime()) {

--- a/web/sites/default/settings.redis.php
+++ b/web/sites/default/settings.redis.php
@@ -2,28 +2,44 @@
 
 use Drupal\Core\Installer\InstallerKernel;
 
-if ((
+if (
   !InstallerKernel::installationAttempted() &&
   extension_loaded('redis') &&
-  class_exists('Drupal\redis\ClientFactory') &&
-  !function_exists('_settings_redis')
-)) {
-  // These settings need to be applied multiple times, depending on how often
-  // initialize is called, they need to be reapplied every time.
-  function _settings_redis(array &$settings, string $host, string $port): void {
+  class_exists('Drupal\redis\ClientFactory')
+) {
+  /**
+   * Apply Redis cache settings.
+   *
+   * Drush can be bootstrap Drupal twice, this should be safe to be called
+   * multiple times.
+   *
+   * @param array $settings
+   *   The $settings array from settings.php.
+   * @param string $host
+   *   The host that Redis will be contacted on.
+   * @param string $port
+   *   The port that Redis will be contacted on.
+   * @param string $interface
+   *   This can be 'Relay', 'PhpRedis', or 'Predis'. PhpRedis is fastest, Predis
+   *
+   * @return void
+   */
+  function _drupal_env_settings_redis(array &$settings, string $host, string $port, string $interface = ''): void {
     $settings['redis.connection']['host'] = $host;
     $settings['redis.connection']['port'] = $port;
-    $settings['redis.connection']['interface'] = 'PhpRedis'; // Can be "Predis".
-    # Use for all bins otherwise specified.
+    if (!empty($interface)) {
+      $settings['redis.connection']['interface'] = $interface;
+    }
+    // Use for all bins otherwise specified.
     $settings['cache']['default'] = 'cache.backend.redis';
 
-    // Optional settings:
+    /* Optional settings:
 
-    // Apply changes to the container configuration to better leverage Redis.
-    // This includes using Redis for the lock and flood control systems, as well
-    // as the cache tag checksum. Alternatively, copy the contents of that file
-    // to your project-specific services.yml file, modify as appropriate, and
-    // remove this line.
+    Apply changes to the container configuration to better leverage Redis.
+    This includes using Redis for the lock and flood control systems, as well
+    as the cache tag checksum. Alternatively, copy the contents of that file
+    to your project-specific services.yml file, modify as appropriate, and
+    remove this line. */
     $settings['container_yamls'][] = 'modules/contrib/redis/example.services.yml';
 
     // Allow the services to work before the Redis module itself is enabled.
@@ -38,7 +54,6 @@ if ((
   }
 
   // These only need to be done once, then they are included and applied always.
-
   // Manually add the classloader path, this is required for the container cache bin definition below
   // and allows to use it without the redis module being enabled.
   $class_loader->addPsr4('Drupal\\redis\\', 'modules/contrib/redis/src');

--- a/web/sites/default/settings.redis.php
+++ b/web/sites/default/settings.redis.php
@@ -8,35 +8,39 @@ if ((
   class_exists('Drupal\redis\ClientFactory') &&
   !function_exists('_settings_redis')
 )) {
+  // These settings need to be applied multiple times, depending on how often
+  // initialize is called, they need to be reapplied every time.
   function _settings_redis(array &$settings, string $host, string $port): void {
     $settings['redis.connection']['host'] = $host;
     $settings['redis.connection']['port'] = $port;
+    $settings['redis.connection']['interface'] = 'PhpRedis'; // Can be "Predis".
+    # Use for all bins otherwise specified.
+    $settings['cache']['default'] = 'cache.backend.redis';
+
+    // Optional settings:
+
+    // Apply changes to the container configuration to better leverage Redis.
+    // This includes using Redis for the lock and flood control systems, as well
+    // as the cache tag checksum. Alternatively, copy the contents of that file
+    // to your project-specific services.yml file, modify as appropriate, and
+    // remove this line.
+    $settings['container_yamls'][] = 'modules/contrib/redis/example.services.yml';
+
+    // Allow the services to work before the Redis module itself is enabled.
+    $settings['container_yamls'][] = 'modules/contrib/redis/redis.services.yml';
+
+    // Use redis for container cache.
+    // The container cache is used to load the container definition itself, and
+    // thus any configuration stored in the container itself is not available
+    // yet. These lines force the container cache to use Redis rather than the
+    // default SQL cache.
+    require 'settings.redis.container.php';
   }
 
-  $settings['redis.connection']['interface'] = 'PhpRedis'; // Can be "Predis".
-  # Use for all bins otherwise specified.
-  $settings['cache']['default'] = 'cache.backend.redis';
-
-  // Optional settings:
-
-  // Apply changes to the container configuration to better leverage Redis.
-  // This includes using Redis for the lock and flood control systems, as well
-  // as the cache tag checksum. Alternatively, copy the contents of that file
-  // to your project-specific services.yml file, modify as appropriate, and
-  // remove this line.
-  $settings['container_yamls'][] = 'modules/contrib/redis/example.services.yml';
-
-  // Allow the services to work before the Redis module itself is enabled.
-  $settings['container_yamls'][] = 'modules/contrib/redis/redis.services.yml';
+  // These only need to be done once, then they are included and applied always.
 
   // Manually add the classloader path, this is required for the container cache bin definition below
   // and allows to use it without the redis module being enabled.
   $class_loader->addPsr4('Drupal\\redis\\', 'modules/contrib/redis/src');
 
-  require 'settings.redis.container.php';
 }
-
-
-
-
-


### PR DESCRIPTION
To Reproduce (Must be done on a different branch)

1.     Load the site
2.     `lando drush cg entity_field_map discovery`
3.     Note the cache value.
4.     `lando drush cr`
5.     `lando drush cg entity_field_map discovery`
6.     Note the cache value is still there.

After switching to the above, the cache value should be gone after `lando drush cr`.

The problem was that the settings changes needed to be INSIDE the function, otherwise they won't be applied again. Drush initializes the site multiple times and wipes it out, making you use the default cache bin 'memory'.