### PR TITLE
BSD-340: Add the file_resup module to allow large uploads to file fields, enable for the Video file field.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -66,6 +66,7 @@
         "drupal/disable_user_1_edit": "^1.6",
         "drupal/email_username": "^1.0",
         "drupal/field_group": "^3.4",
+        "drupal/file_resup": "^2.0",
         "drupal/google_tag": "^2.0",
         "drupal/imagecache_external": "^3.0",
         "drupal/key": "^1.19",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "7820e27278aea70781632859c325dce0",
+    "content-hash": "03e17041ccf37ab7a7a0d9c85ca1ee6f",
     "packages": [
         {
             "name": "asm89/stack-cors",
@@ -3146,6 +3146,54 @@
             "support": {
                 "source": "https://git.drupalcode.org/project/field_group",
                 "issues": "https://www.drupal.org/project/issues/field_group"
+            }
+        },
+        {
+            "name": "drupal/file_resup",
+            "version": "2.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://git.drupalcode.org/project/file_resup.git",
+                "reference": "2.0.1"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://ftp.drupal.org/files/projects/file_resup-2.0.1.zip",
+                "reference": "2.0.1",
+                "shasum": "e28b507a9fc1efa5abbe09ed2c144ca851d016ca"
+            },
+            "require": {
+                "drupal/core": "^9 || ^10"
+            },
+            "type": "drupal-module",
+            "extra": {
+                "drupal": {
+                    "version": "2.0.1",
+                    "datestamp": "1729175113",
+                    "security-coverage": {
+                        "status": "covered",
+                        "message": "Covered by Drupal's security advisory policy"
+                    }
+                }
+            },
+            "notification-url": "https://packages.drupal.org/8/downloads",
+            "license": [
+                "GPL-2.0-or-later"
+            ],
+            "authors": [
+                {
+                    "name": "anrikun",
+                    "homepage": "https://www.drupal.org/user/410199"
+                },
+                {
+                    "name": "tim bozeman",
+                    "homepage": "https://www.drupal.org/user/2241356"
+                }
+            ],
+            "description": "Allows users to add large files, multiple files, and resume uploads.",
+            "homepage": "https://www.drupal.org/project/file_resup",
+            "support": {
+                "source": "https://git.drupalcode.org/project/file_resup"
             }
         },
         {
@@ -16860,5 +16908,5 @@
     "prefer-lowest": false,
     "platform": [],
     "platform-dev": [],
-    "plugin-api-version": "2.6.0"
+    "plugin-api-version": "2.3.0"
 }

--- a/config/sync/core.extension.yml
+++ b/config/sync/core.extension.yml
@@ -42,6 +42,8 @@ module:
   field_group: 0
   field_ui: 0
   file: 0
+  file_resup: 0
+  file_resup_media_library: 0
   filter: 0
   google_tag: 0
   image: 0

--- a/config/sync/field.field.media.video.field_media_video_file.yml
+++ b/config/sync/field.field.media.video.field_media_video_file.yml
@@ -7,6 +7,12 @@ dependencies:
     - media.type.video
   module:
     - file
+    - file_resup
+third_party_settings:
+  file_resup:
+    enabled: 1
+    max_upload_size: '4 GB'
+    auto_upload: 0
 id: media.video.field_media_video_file
 field_name: field_media_video_file
 entity_type: media
@@ -21,7 +27,7 @@ settings:
   handler: 'default:file'
   handler_settings: {  }
   file_directory: '[date:custom:Y]-[date:custom:m]'
-  file_extensions: 'mp4 webm'
-  max_filesize: '300 MB'
+  file_extensions: 'mp4 webm m4v'
+  max_filesize: ''
   description_field: false
 field_type: file

--- a/config/sync/user.role.site_admin.yml
+++ b/config/sync/user.role.site_admin.yml
@@ -8,6 +8,7 @@ dependencies:
     - config_pages
     - contact
     - cookies
+    - file_resup
     - google_tag
     - path
     - pathauto
@@ -28,6 +29,7 @@ permissions:
   - 'administer CAPTCHA settings'
   - 'administer contact forms'
   - 'administer cookies services and service groups'
+  - 'administer file resup'
   - 'administer google_tag_container'
   - 'administer pathauto'
   - 'administer recaptcha'


### PR DESCRIPTION
* Add the [file_resup](https://drupal.org/project/file_resup) module to enable uploads larger than supported by the webserver or PHP
* Enable on the Video media type.

With this, a video file can be added to a node via CKEditor's Add Media button.