### PR TITLE
BSD-247: For a11y, add underline to links that look like buttons.

### DIFF
--- a/stories/assets/styles/global/global.scss
+++ b/stories/assets/styles/global/global.scss
@@ -200,8 +200,8 @@ li:not(#toolbar-administration li) {
 
 a {
   color: inherit;
-  text-decoration-thickness: 2px;
-  text-underline-offset: 2px;
+  text-decoration-thickness: 1px;
+  text-underline-offset: 3px;
 }
 
 p {

--- a/stories/components/button/button.scss
+++ b/stories/components/button/button.scss
@@ -12,7 +12,6 @@
   line-height: 1;
   outline-color: var(--c-accent-cool-alt);
   padding: units(2) units(3);
-  text-decoration: none;
   transition: 0.2s ease-in;
 
   &:hover,
@@ -25,6 +24,10 @@
   svg {
     fill: currentColor;
   }
+}
+
+a.bix-button {
+  text-decoration: revert;
 }
 
 .bix-button--icon-before {


### PR DESCRIPTION
<!--
  **PR title**

  **Feature PR's**
  - BSD fixes #ISSUE_NO: Brief description
  - BSD-ISSUE_NO: Brief description

  **Releases**
  Release/RELEASE_NO
-->

# Summary

Adds an underline to links that look like buttons to make it clear that it is a link. 

## Related issue

Closes #247.

## Solution

Adjusted default link styles and reverted the text decoration property on links that have the button class.

## Testing and review

Links that look like buttons should have an underline.

**Example**
The "Work with us" in the footer:
<img width="150" alt="capture-Arc-2025-03-06@2x" src="https://github.com/user-attachments/assets/d8af3abe-3f45-48ca-9b8e-5ae7f25a7b4a"/>


<!--
## Dependencies

Dependency updates (if any, uncomment this section).

| Dependency                   | Old      | New     |
| :--------------------------- | :------- | :------ |
| [Updated dependency example] | [1.0.0]  | [1.0.1] |
| [New dependency example]     | --       | [3.0.1] |
| [Removed dependency example] | [2.10.2] | --      |
-->
