### PR TITLE
BSD-98: Add a unique aria label to footer social links

### DIFF
--- a/stories/components/footer/footer.stories.js
+++ b/stories/components/footer/footer.stories.js
@@ -12,9 +12,12 @@ export default {
   title: "Components/Footer",
   component: Footer,
   args: {
-    socialNav: SocialNav.default.args,
-    ...FooterContent
-  }
+    socialNav: {
+      ...SocialNav.default.args,
+      aria_label: "Bixal social links",
+    },
+    ...FooterContent,
+  },
 };
 
 export const Default = {};

--- a/web/modules/custom/site_wrapper/site_wrapper.module
+++ b/web/modules/custom/site_wrapper/site_wrapper.module
@@ -133,7 +133,7 @@ function template_preprocess_site_wrapper_footer(array &$variables): void {
   }
   $variables['socialNav'] = [
     'variant' => NULL,
-    'aria_label' => t('Social links'),
+    'aria_label' => t('Bixal social links'),
     'items' => [
       [
         "href" => "https://www.linkedIn.com/company/bixal",


### PR DESCRIPTION
<!--
  **PR title**

  **Feature PR's**
  - BSD fixes #ISSUE_NO: Brief description
  - BSD-ISSUE_NO: Brief description

  **Releases**
  Release/RELEASE_NO
-->

# Summary

Gives the footer social nav a unique aria label to address a11y issue of duplicate labels.

## Related issue

Closes #98.

<!--
  Every pull request should have a related issue.
  If one doesn't exist, create one here:
  https://github.com/Bixal/bixal-site-drupal/issues/new/choose
-->

## Solution

Gave a unique label to the Footer social nav.

Should read:
```
Bixal social links
```

## Testing and review

1. Visit the profile story
2. Confirm that the aria-label on social navs are different

<!--
## Dependencies

Dependency updates (if any, uncomment this section).

| Dependency                   | Old      | New     |
| :--------------------------- | :------- | :------ |
| [Updated dependency example] | [1.0.0]  | [1.0.1] |
| [New dependency example]     | --       | [3.0.1] |
| [Removed dependency example] | [2.10.2] | --      |
-->
