### PR TITLE
BSD-242: Improve about filter accessibility

### DIFF
--- a/stories/_utils/toggle.js
+++ b/stories/_utils/toggle.js
@@ -62,10 +62,4 @@ function toggle(event) {
   }
 }
 
-export {
-  activeClass,
-  checkActive,
-  show,
-  hide,
-  toggle,
-};
+export { activeClass, checkActive, show, hide, toggle, isActive };

--- a/stories/_utils/toggle.js
+++ b/stories/_utils/toggle.js
@@ -4,6 +4,7 @@
 
 const activeClass = "is-active";
 
+let isActive = false;
 
 /**
  * Check if element has active class.
@@ -50,9 +51,9 @@ function hide(trigger, target) {
  */
 function toggle(event) {
   const trigger = event.currentTarget;
-  const target = document.getElementById(trigger.getAttribute("aria-controls"))
+  const target = document.getElementById(trigger.getAttribute("aria-controls"));
 
-  const isActive = checkActive(trigger);
+  isActive = checkActive(trigger);
 
   if (!isActive) {
     show(trigger, target);

--- a/stories/assets/styles/global/global.scss
+++ b/stories/assets/styles/global/global.scss
@@ -239,6 +239,10 @@ address {
   margin-bottom: units(3);
 }
 
+.sr-only {
+  @include sr-only;
+}
+
 .bix-container {
   height: 100%;
   margin: 0 auto;

--- a/stories/assets/styles/global/global.scss
+++ b/stories/assets/styles/global/global.scss
@@ -193,7 +193,7 @@ ol {
   }
 }
 
-li:not(#toolbar-administration li) {
+li:with(:not(#toolbar-administration li)) {
   margin-bottom: units(1);
 }
 

--- a/stories/components/people-list/people-list.html.twig
+++ b/stories/components/people-list/people-list.html.twig
@@ -48,7 +48,7 @@
       </button>
 
       {% if filter_options %}
-        <p class="" aria-live="polite">
+        <p class="sr-only" aria-live="polite">
           {{ "Total number of visible items "|t }}
           <span data-total-visible-count></span>
         </p>

--- a/stories/components/people-list/people-list.html.twig
+++ b/stories/components/people-list/people-list.html.twig
@@ -48,28 +48,37 @@
       </button>
 
       {% if filter_options %}
-        <div
+        <p class="" aria-live="polite">
+          {{ "Total number of visible items "|t }}
+          <span data-total-visible-count></span>
+        </p>
+
+        <fieldset
           id="bix-filter-dropdown"
           class="bix-filter__dropdown-options"
           data-dropdown-options>
+          <ol>
           {% for option in filter_options %}
-            <label
-              for="{{ option | lower }}"
-              class="bix-filter__dropdown-option">
+            <li class="bix-filter__dropdown-option">
               <input
                 type="radio"
                 name="filter"
                 id="{{ option | lower }}"
                 value="{{ option | lower }}"
                 {{ loop.first ? "checked" }}>
-              {{ option | capitalize }}
-            </label>
+              <label
+                for="{{ option | lower }}"
+                class="bix-filter__dropdown-option">
+                {{ option | capitalize }}
+              </label>
+            </li>
           {% endfor %}
-        </div>
+          </ol>
+        </fieldset>
       {% endif %}
     </div>
     {% if filter_content %}
-      <ul class="bix-people-list">
+      <ul class="bix-people-list" aria-live="polite">
         {% for item in filter_content %}
           <li
             class="bix-people-list__item bix-person{% if loop.index > 20 %} view-all-only{% endif %}"
@@ -85,7 +94,7 @@
                 <img
                   src="{{ item.image | default("https://placehold.co/325x325") }}"
                   aria-hidden="true">
-                <div class="bix-person__overlay">
+                <div class="bix-person__overlay" aria-hidden="true">
                   View all
 
                   {# @TODO: Allow aria-hidden to be configurable. #}

--- a/stories/components/people-list/people-list.js
+++ b/stories/components/people-list/people-list.js
@@ -17,6 +17,23 @@ window.addEventListener("DOMContentLoaded", () => {
   const footer = document.querySelector(".bix-people__footer");
 
   /**
+   * Get the total visible count of people and update a screen reader only message with the current visible count.
+   *
+   * @returns {void}
+   */
+  function setVisibleCount() {
+    const totalVisibleItems = document.querySelectorAll(
+      ".bix-person:not([hidden])",
+    ).length;
+
+    const srOnlyVisibleCount = document.querySelector(
+      "[data-total-visible-count]",
+    );
+
+    srOnlyVisibleCount.textContent = totalVisibleItems;
+  }
+
+  /**
    * Basic content filtering.
    *
    * @param {Event} event
@@ -54,6 +71,8 @@ window.addEventListener("DOMContentLoaded", () => {
       }
       person.setAttribute("hidden", "");
     });
+
+    setVisibleCount();
   }
 
   /**
@@ -92,6 +111,8 @@ window.addEventListener("DOMContentLoaded", () => {
    */
   function init() {
     target.setAttribute("hidden", "");
+
+    setVisibleCount();
 
     document.addEventListener("keydown", (event) => {
       const hasChildFocus = target.contains(document.activeElement);

--- a/stories/components/people-list/people-list.js
+++ b/stories/components/people-list/people-list.js
@@ -2,16 +2,19 @@ import * as Toggle from "../../_utils/toggle.js";
 
 window.addEventListener("DOMContentLoaded", () => {
   const trigger = document.querySelector("[data-dropdown-toggle]");
+
   if (!trigger) {
     return;
   }
+
   const target = document.getElementById(trigger.getAttribute("aria-controls"));
-  // const filterOptions = target.querySelectorAll(".bix-filter__dropdown-option");
   const filterItems = document.querySelectorAll(".bix-person");
+
   if (!filterItems) {
     return;
   }
-  const footer = document.querySelector('.bix-people__footer');
+  
+  const footer = document.querySelector(".bix-people__footer");
 
   /**
    * Basic content filtering.
@@ -19,14 +22,16 @@ window.addEventListener("DOMContentLoaded", () => {
    * @param {Event} event
    */
   function filterContent(event) {
-    const isOption = event.target.classList.contains("bix-filter__dropdown-option");
+    const isOption = event.target.classList.contains(
+      "bix-filter__dropdown-option",
+    );
 
     // Avoids having to set an even listener on *every* option.
     if (!isOption) {
       return;
     }
     // After a filter is chosen, hide the popup.
-    Toggle.hide(trigger, target)
+    Toggle.hide(trigger, target);
     // If a filter is chosen, show all results and hide the 'view all' button.
     removeContentLimit();
 
@@ -34,8 +39,8 @@ window.addEventListener("DOMContentLoaded", () => {
     const chosenFilterValue = option.getAttribute("for");
 
     // @TODO: Check for scrollbar and adjust body padding to avoid screen "shake" when there are zero items.
-    [...filterItems].map(person => {
-      const bixalersFilterCategory = person.dataset.filterCategory.split('|||');
+    [...filterItems].map((person) => {
+      const bixalersFilterCategory = person.dataset.filterCategory.split("|||");
       person.removeAttribute("hidden");
       if (chosenFilterValue === "all") {
         return;
@@ -55,17 +60,17 @@ window.addEventListener("DOMContentLoaded", () => {
    * Remove content number limit.
    */
   function removeContentLimit() {
-    const footer = document.querySelector('.bix-people__footer');
+    const footer = document.querySelector(".bix-people__footer");
     if (!footer) {
       return;
     }
     const style = window.getComputedStyle(footer);
-    if (style.visibility === 'hidden') {
+    if (style.visibility === "hidden") {
       return;
     }
     const hiddenExtraItems = document.querySelectorAll(".view-all-only");
-    [...hiddenExtraItems].map(person => {
-      person.classList.remove('view-all-only');
+    [...hiddenExtraItems].map((person) => {
+      person.classList.remove("view-all-only");
     });
     footer.setAttribute("hidden", "");
   }
@@ -85,4 +90,4 @@ window.addEventListener("DOMContentLoaded", () => {
   }
 
   init();
-})
+});

--- a/stories/components/people-list/people-list.js
+++ b/stories/components/people-list/people-list.js
@@ -13,7 +13,7 @@ window.addEventListener("DOMContentLoaded", () => {
   if (!filterItems) {
     return;
   }
-  
+
   const footer = document.querySelector(".bix-people__footer");
 
   /**
@@ -75,14 +75,38 @@ window.addEventListener("DOMContentLoaded", () => {
     footer.setAttribute("hidden", "");
   }
 
+  function toggleDropdown(event) {
+    Toggle.toggle(event);
+
+    if (!Toggle.isActive) {
+      const selectedItem = target.querySelector('input[type="radio"]:checked');
+      selectedItem.focus();
+      return;
+    }
+
+    trigger.focus();
+  }
+
   /**
    * Hides menu initially and then uses Toggle utility to show/hide.
    */
   function init() {
     target.setAttribute("hidden", "");
 
-    trigger.addEventListener("click", Toggle.toggle);
+    document.addEventListener("keydown", (event) => {
+      const hasChildFocus = target.contains(document.activeElement);
+
+      if (
+        (event.key === "Escape" && !target.hasAttribute("hidden")) ||
+        !hasChildFocus
+      ) {
+        Toggle.hide(trigger, target);
+      }
+    });
+
+    trigger.addEventListener("click", toggleDropdown);
     target.addEventListener("click", filterContent);
+
     // Add a click event to the 'View All' button.
     if (footer) {
       footer.children[0].addEventListener("click", removeContentLimit);

--- a/stories/components/people-list/people-list.scss
+++ b/stories/components/people-list/people-list.scss
@@ -7,29 +7,26 @@
 }
 
 .bix-filter__dropdown {
+  margin-block-start: units(5);
   text-align: center;
   position: relative;
   z-index: 1;
 
   &-button {
     @extend %filter-base-text-styles;
-    border-bottom: 2px solid;
+    border-block-end: 2px solid;
     font-size: px-to-rem(16px);
-    margin-bottom: units(4);
-    padding-top: units(1);
-    padding-bottom: units(1);
+    margin-block-end: units(4);
+    padding-block-start: units(1);
+    padding-block-end: units(1);
 
     &.is-active {
       border-bottom-color: var(--c-accent-cool-alt);
-    }
 
-  }
-
-  &-button.is-active {
-
-    // Flip the caret vertically when active.
-    .bix-icon--caret {
-      transform: scaleY(-1);
+      // Flip the caret vertically when active.
+      .bix-icon--caret {
+        transform: scaleY(-1);
+      }
     }
   }
 
@@ -47,8 +44,6 @@
     // 1. USWDS `tablet` token is 640px.
     //    https://designsystem.digital.gov/design-tokens/spacing-units/
     @include at-media("tablet") {
-      columns: 3;
-      gap: units(4);
       margin-left: auto;
       margin-right: auto;
       max-width: units("tablet"); // 1
@@ -56,22 +51,33 @@
     }
   }
 
+  &-options ol {
+    columns: 3;
+    gap: units(4);
+    list-style: none;
+    margin-block-start: 0;
+    margin-block-end: 0;
+    padding: 0;
+  }
+
   &-option {
     cursor: pointer;
     display: block;
     line-height: 1;
-    margin-bottom: units(3);
+    margin-block-end: units(3);
     text-align: left;
     transition: color 0.25s;
   }
 
   &-option:last-child {
-    margin-bottom: 0;
+    margin-block-end: 0;
   }
 
   // Selected option.
-  &-option:has(input:checked) {
+  &-option input:checked + label,
+  &-option :is(:focus, :active, :hover) {
     color: var(--c-primary-alt);
+    text-decoration: underline;
   }
 
   // The radio button.
@@ -86,7 +92,8 @@
   grid-template-columns: repeat(auto-fill, minmax(140px, 244px));
   row-gap: units(7);
   list-style: none;
-  padding-left: 0;
+  margin-block-start: 0;
+  padding-inline-start: 0;
   justify-content: center;
 }
 
@@ -134,14 +141,14 @@
   }
 
   &__details {
-    padding-top: units(2);
-    padding-right: units(2);
+    padding-block-start: units(2);
+    padding-inline-end: units(2);
   }
 
   &__name {
     font-size: px-to-rem(24px);
     letter-spacing: -0.33px;
-    margin-bottom: units("05");
+    margin-block-end: units("05");
   }
 
   &__role {


### PR DESCRIPTION
# Summary

This work adds some accessibility improvements to the current People filter component.

## Related issue

Closes #242.

## Solution

The original accessibility recommendation was to completely remove it, which seems like a harsh and time intensive route. These changes require some markup changes:

1. A screen reader only counter for total number of visible elements.
2. A fieldset for wrapping the dropdown items
3. Aria attributes to improve context in screen readers
4. Dropdown now closes via <kbd>ESC</kbd> and when out of focus.

## Testing and review

You'll need a screen reader to test the full changes, but there are some things you can test without:

1. On opening the dropdown, you should be able to use the arrow keys to navigate.
2. You can close the dropdown with <kbd>Esc</kbd> or by switching focus.
3. Inspect and see the `sr-only` paragraph update with the total number of visible items.

<!--
## Dependencies

Dependency updates (if any, uncomment this section).

| Dependency                   | Old      | New     |
| :--------------------------- | :------- | :------ |
| [Updated dependency example] | [1.0.0]  | [1.0.1] |
| [New dependency example]     | --       | [3.0.1] |
| [Removed dependency example] | [2.10.2] | --      |
-->
