### PR TITLE
BSD-398: icon component

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,9 +7,6 @@
 .AppleDouble
 .LSOverride
 
-# Icon must end with two \r
-Icon
-
 
 # Thumbnails
 ._*

--- a/.storybook/main.js
+++ b/.storybook/main.js
@@ -17,13 +17,13 @@ const config = {
   docs: {
     autodocs: "tag",
   },
-  staticDirs: ['../stories/assets'],
+  staticDirs: ["../stories/assets", "../node_modules/@uswds/uswds/dist"],
   async viteFinal(config, { configType }) {
-      // This allows starting this in a sub dir:
-      // BASE_PATH=/sb npm run build-storybook
-      config.base = process.env.BASE_PATH || config.base;
-      // return the customized config
-      return config;
-    },
+    // This allows starting this in a sub dir:
+    // BASE_PATH=/sb npm run build-storybook
+    config.base = process.env.BASE_PATH || config.base;
+    // return the customized config
+    return config;
+  },
 };
 export default config;

--- a/README.md
+++ b/README.md
@@ -44,6 +44,13 @@ More guidance on git branches and commit style in [robo.yml](https://github.com/
 
 ### Starting the Environment
 
+#### Prerequisites
+
+- php@8.1
+- lando
+
+#### Installing
+
 First time:
 
 ```

--- a/README.md
+++ b/README.md
@@ -115,10 +115,18 @@ It's important that you always use `lando composer` or `./composer.sh` instead o
 
 [Storybook](https://storybook.js.org/) for this project can be found by:
 
-- Docker version: http://storybook.bixalcom.lndo.site/
-- Local version:
-  - ./sb.sh
-  - This should automatically open it in your browser.
+**Docker URL**
+
+http://storybook.bixalcom.lndo.site/
+
+**Local version**
+
+```bash
+# Run in terminal.
+./sb.sh
+```
+
+This should automatically open it in your browser.
 
 ### Handy Commands for Development
 

--- a/stories/components/icon/icon-demo.html.twig
+++ b/stories/components/icon/icon-demo.html.twig
@@ -1,0 +1,36 @@
+<style>
+  .icon-demo {
+    display: grid;
+    grid-template-columns: repeat(
+      auto-fit,
+      minmax(min(100%, 20ch), 1fr)
+    );
+    justify-content: center;
+    align-items: center;
+    text-align: center;
+  }
+
+  .icon-demo__item {
+    border: 1px solid lightgray;
+    margin-block-end: -1px;
+    margin-inline-end: -1px;
+    padding: 2rem 1.5rem;
+  }
+
+  p {
+    font-size: 0.8rem;
+    font-family: monospace;
+    margin-block: 0;
+  }
+</style>
+
+<div class="icon-demo">
+  {% for icon in icons %}
+    <div class="icon-demo__item">
+      {% include "@components/icon/icon.html.twig" with {
+        icon_name: icon.name,
+      } %}
+      <p>{{ icon.name }}</p>
+    </div>
+  {% endfor %}
+</div>

--- a/stories/components/icon/icon.html.twig
+++ b/stories/components/icon/icon.html.twig
@@ -1,0 +1,13 @@
+A single USWDS icon.
+
+{% set icon_path = "/assets/img/sprite.svg" %}
+{% set icon_name = ""|default("assessment") %}
+
+<svg class="usa-icon" aria-hidden="true" focusable="false" role="img">
+  <use href="{{ icon_path }}#{{ icon_name }}></use>
+</svg>
+
+
+<svg class="usa-icon" aria-hidden="true" focusable="false" role="img">
+  <use href="/assets/img/sprite.svg#assessment"></use>
+</svg>

--- a/stories/components/icon/icon.html.twig
+++ b/stories/components/icon/icon.html.twig
@@ -1,13 +1,28 @@
-A single USWDS icon.
+{#
+/**
+  * USA Icon component
+  *
+  * Available variables:
+  * - icon_path (string, optional): The path to the USWDS SVG sprite. StorybookJS resolves via `staticDirs` option.
+  * - icon_name(string, optional): The name of the icon. Defaults to "assessment."
+  * - icon_size(string, optional): The size of the icon.
+**/
+#}
 
-{% set icon_path = "/assets/img/sprite.svg" %}
-{% set icon_name = ""|default("assessment") %}
 
-<svg class="usa-icon" aria-hidden="true" focusable="false" role="img">
-  <use href="{{ icon_path }}#{{ icon_name }}></use>
-</svg>
+{% set icon_path = icon_path|default("img/sprite.svg") %}
+{% set icon_name = icon_name|default("assessment") %}
+{% set icon_size = icon_size|default("") %}
 
+{% if attributes is empty %}
+  {% set attributes = create_attribute() %}
+{% endif %}
 
-<svg class="usa-icon" aria-hidden="true" focusable="false" role="img">
-  <use href="/assets/img/sprite.svg#assessment"></use>
+{% set icon_classes = [
+  "usa-icon",
+  (icon_size ? "usa-icon--size-" ~ icon_size),
+]| merge(additional_classes | default([])) %}
+
+<svg {{ attributes.addClass(icon_classes) }} aria-hidden="true" focusable="false" role="img">
+  <use href="{{ icon_path }}#{{ icon_name }}"></use>
 </svg>

--- a/stories/components/icon/icon.scss
+++ b/stories/components/icon/icon.scss
@@ -1,0 +1,1 @@
+@forward "usa-icon";

--- a/stories/components/icon/icon.stories.js
+++ b/stories/components/icon/icon.stories.js
@@ -1,0 +1,31 @@
+import Icon from "./icon.html.twig";
+
+export default {
+  title: "Components/Icon",
+  component: Icon,
+  argTypes: {
+    name: { control: "text" },
+    size: {
+      control: { type: "select" },
+      options: ["small", "medium", "large"],
+    },
+    color: { control: "color" },
+  },
+};
+
+// Default story
+export const Default = {};
+// Default.args = {};
+
+// Additional story variations can be added here
+// export const Small = Template.bind({});
+// Small.args = {
+//   name: 'small-icon',
+//   size: 'small',
+// };
+
+// export const Large = Template.bind({});
+// Large.args = {
+//   name: 'large-icon',
+//   size: 'large',
+// };

--- a/stories/components/icon/icon.stories.js
+++ b/stories/components/icon/icon.stories.js
@@ -1,13 +1,19 @@
 import Icon from "./icon.html.twig";
+import IconDemo from "./icon-demo.html.twig";
+
+import "./icon.scss";
+import IconConfig from "../../../node_modules/@uswds/uswds/packages/usa-icon/src/usa-icon.json";
+
+const unitSizes = IconConfig.icons.sizes.map((size) => size.units);
 
 export default {
   title: "Components/Icon",
   component: Icon,
   argTypes: {
     name: { control: "text" },
-    size: {
+    icon_size: {
       control: { type: "select" },
-      options: ["small", "medium", "large"],
+      options: unitSizes,
     },
     color: { control: "color" },
   },
@@ -15,17 +21,16 @@ export default {
 
 // Default story
 export const Default = {};
-// Default.args = {};
+Default.args = {};
 
-// Additional story variations can be added here
-// export const Small = Template.bind({});
-// Small.args = {
-//   name: 'small-icon',
-//   size: 'small',
-// };
+export const AllIcons = {
+  args: {
+    icons: IconConfig.icons.items,
+    sizes: IconConfig.icons.sizes,
+  },
+  render: IconDemo,
+};
 
-// export const Large = Template.bind({});
-// Large.args = {
-//   name: 'large-icon',
-//   size: 'large',
-// };
+export const AllSizes = () => {
+  return unitSizes.map((size) => Icon({ icon_size: size })).join("");
+};


### PR DESCRIPTION
# Summary

Adds support for using USA Icon inline.

**How to use**

```twig
{% include "@components/icon/icon.html.twig" with {
  icon_name: "alternate_email",
  icon_size: 9
} %}
```

Supports all icons listed in https://designsystem.digital.gov/components/icon/.

## Related issue

Closes #398.

<!--
  Every pull request should have a related issue.
  If one doesn't exist, create one here:
  https://github.com/Bixal/bixal-site-drupal/issues/new/choose
-->

## Solution

I've added the USWDS directory to storybook so we can resolve the icons. In the Drupal theme the path looks like this:

```diff
- {{ directory }}/dist/assets/img/sprite.svg#rss_feed"


+ {% include "@components/icon/icon.html.twig" with {
+  icon_path: directory ~ "/dist/assets/img/sprite.svg"
+  icon_name: "alternate_email",
+  icon_size: 9
+ } %}
```

## Testing and review

1. Run storybook locally via `npm run storybook:local`
2. Search for icons in nav, you should see three variants
3. Icons should render correctly


![capture-Arc-2025-04-01@2x](https://github.com/user-attachments/assets/39a0386e-132d-4e2e-9333-3f9e07e111dd)


<!--
## Dependencies

Dependency updates (if any, uncomment this section).

| Dependency                   | Old      | New     |
| :--------------------------- | :------- | :------ |
| [Updated dependency example] | [1.0.0]  | [1.0.1] |
| [New dependency example]     | --       | [3.0.1] |
| [Removed dependency example] | [2.10.2] | --      |
-->
