### PR TITLE
BSD-408: Only add keyboard events to mobile

### DIFF
--- a/stories/components/header/header.js
+++ b/stories/components/header/header.js
@@ -72,8 +72,10 @@ window.addEventListener("DOMContentLoaded", () => {
    */
   function handleResize(breakpoint) {
     if (breakpoint.matches) {
+      document.removeEventListener("keyup", handleKeyboard);
       openMenu();
     } else {
+      document.addEventListener("keyup", handleKeyboard);
       closeMenu();
     }
   }
@@ -82,11 +84,9 @@ window.addEventListener("DOMContentLoaded", () => {
    * Add event listeners.
    */
   function init() {
-    // @TODO: Add a focus trap for A11Y.
     handleResize(desktopBreakpoint);
     menuTrigger.addEventListener("click", handleClick);
     desktopBreakpoint.addEventListener("change", handleResize);
-    document.addEventListener("keyup", handleKeyboard);
   }
 
   init();


### PR DESCRIPTION
<!--
  **PR title**

  **Feature PR's**
  - BSD fixes #ISSUE_NO: Brief description
  - BSD-ISSUE_NO: Brief description

  **Releases**
  Release/RELEASE_NO
-->

# Summary

Fixes a bug where mobile keyboard events were being triggered on desktop.

## Related issue

Closes #408.

<!--
  Every pull request should have a related issue.
  If one doesn't exist, create one here:
  https://github.com/Bixal/bixal-site-drupal/issues/new/choose
-->

## Solution

Adding and removing keyboard toggle based on breakpoint.

## Testing and review

1. Confirm that there aren't regressions on mobile, you should still be able to toggle.
2. Confirm there aren't regressions on desktop.
3. Resize viewport  and confirm functionality on both small/large screens.
4. Resize viewport with mobile nav open/closed and desktop menu should still appear.
5. On desktop, try typing keys to ensure that the menu doesn't disappear.

<!--
## Dependencies

Dependency updates (if any, uncomment this section).

| Dependency                   | Old      | New     |
| :--------------------------- | :------- | :------ |
| [Updated dependency example] | [1.0.0]  | [1.0.1] |
| [New dependency example]     | --       | [3.0.1] |
| [Removed dependency example] | [2.10.2] | --      |
-->
