### PR TITLE
BSD fixes #413: Require components to be @forwarded to Drupal

### DIFF
--- a/.github/workflows/run-validation.yml
+++ b/.github/workflows/run-validation.yml
@@ -46,22 +46,9 @@ jobs:
             -   name: Validate a change to any branch
                 if: github.event_name == 'push'
                 run: |
-                    # Initialize status variables to 0
-                    status1=0
-                    status2=0
-                    status3=0
-
-                    # Run all commands and capture their exit statuses
-                    vendor/bin/robo validate:branch-name || status1=$? || status1=0
-                    vendor/bin/robo validate:composer-lock || status3=$? || status3=0
-                    vendor/bin/robo validate:coding-standards || status2=$? || status2=0
-
-                    # Exit with a non-zero status if any command failed
-                    if [ "$status1" -ne 0 ] || [ "$status2" -ne 0 ] || [ "$status3" -ne 0 ]; then
-                      exit 1
-                    fi
+                    ROBO_VALIDATE_BRANCH_NAME=${{ github.head_ref }} vendor/bin/robo validate:all non_pr
 
             -   name: Validate pull requests
                 if: github.event_name == 'pull_request'
                 run: |
-                    vendor/bin/robo validate:commit-messages --target-branch="${{ github.base_ref }}" --current-branch="${{ github.head_ref }}"
+                    ROBO_VALIDATE_TARGET_BRANCH="${{ github.base_ref }}" ROBO_VALIDATE_CURRENT_BRANCH="${{ github.head_ref }}" vendor/bin/robo validate:all only_pr

--- a/robo.yml
+++ b/robo.yml
@@ -53,3 +53,11 @@ command:
                     - 'semantic_end_0|release'
                     # Matches a branch named 'stage' (MOD FROM DEFAULTS).
                     - 'explicit|stage'
+        all:
+            options:
+                commands:
+                    - {robo_command: 'validate:coding-standards', label: 'Coding Standards'}
+                    - {robo_command: 'validate:composer-lock', label: 'Composer Lock File'}
+                    - {robo_command: 'validate:commit-messages', label: 'Commit Messages', only_pr: 1}
+                    - {robo_command: 'validate:branch-name', label: 'Branch Name'}
+                    - {robo_command: 'validate-components', label: 'Storybook components forwarded to Drupal'}

--- a/stories/_index.scss
+++ b/stories/_index.scss
@@ -6,10 +6,12 @@
 @forward "components/contact-us/contact-us";
 @forward "components/description-list/description-list";
 @forward "components/emphasis-block/emphasis-block";
+@forward "components/_example/example";
 @forward "components/footer/footer";
 @forward "components/graphic-list/graphic-list";
 @forward "components/header/header";
 @forward "components/hero/hero";
+@forward "components/icon/icon";
 @forward "components/people-list/people-list";
 @forward "components/profile/profile";
 @forward "components/prose/prose";


### PR DESCRIPTION
# Summary

Wrote a script to enforce components being added to `./stories/_index.scss`.

## Solution

<!--
A summary of the solution this PR offers.

It can be helpful if we understand:
1. What the solution is,
2. Why this approach was chosen,
3. How you implemented the change, and
4. Possible limitations of this approach and alternate solution paths.
-->

## Testing and review

`./robo.sh validate:all` should run without error.
Edit `./stories/_index.scss` and remove a line and run the above again, it should error.
