### PR TITLE
BSD-415: Avoid wrapping unformatted rows if classes are empty

### DIFF
--- a/web/themes/custom/bixal_uswds/templates/views/views-view-unformatted.html.twig
+++ b/web/themes/custom/bixal_uswds/templates/views/views-view-unformatted.html.twig
@@ -24,7 +24,12 @@
       default_row_class ? 'views-row',
     ]
   %}
-  <div{{ row.attributes.addClass(row_classes) }}>
+
+  {% if row_classes[0] is empty %}
     {{- row.content -}}
-  </div>
+  {% else %}
+    <div{{ row.attributes.addClass(row_classes) }}>
+      {{- row.content -}}
+    </div>
+  {% endif %}
 {% endfor %}


### PR DESCRIPTION
Prevents an issue with malformed HTML where divs are direct children of an unordered list

<!--
  **PR title**

  **Feature PR's**
  - BSD fixes #ISSUE_NO: Brief description
  - BSD-ISSUE_NO: Brief description

  **Releases**
  Release/RELEASE_NO
-->

# Summary

Fixes malformed HTML that's causing an a11y issue. Divs should **not** be direct children of lists.

## Related issue

Closes #415.

<!--
  Every pull request should have a related issue.
  If one doesn't exist, create one here:
  https://github.com/Bixal/bixal-site-drupal/issues/new/choose
-->

## Solution

Directly rendering content if `row_classes[0]` is an empty string.

## Testing and review

1. Locally, visit https://bixalcom.lndo.site/blog
2. Inspect the blog teasers
3. The markup should be `ul > li`

<!--
How to test this work.

1. Describe the tests that you ran to verify your changes
4. Provide instructions to reproduce
5. Clarify the type of feedback you are looking for
-->

<!--
## Dependencies

Dependency updates (if any, uncomment this section).

| Dependency                   | Old      | New     |
| :--------------------------- | :------- | :------ |
| [Updated dependency example] | [1.0.0]  | [1.0.1] |
| [New dependency example]     | --       | [3.0.1] |
| [Removed dependency example] | [2.10.2] | --      |
-->
