### PR TITLE
BSD-427: Add Bixal button classes to form buttons

### DIFF
--- a/web/themes/custom/bixal_uswds/templates/form/input.html.twig
+++ b/web/themes/custom/bixal_uswds/templates/form/input.html.twig
@@ -24,13 +24,13 @@
   {% set button_type = element["#button_type"] %}
 {% endif %}
 
-{# Set various classes to adhere to USWDS form classes. #}
+{# Set USWDS and Bixal theme classes. #}
 {% set classes = [
   type in ['checkbox', 'radio'] ? 'usa-' ~ type ~ '__input',
   type in ['password', 'password_confirm', 'text', 'tel', 'number', 'url', 'email', 'date', 'time'] ? 'usa-input',
   type in ['file', 'managed_file'] ? 'usa-file-input',
-  type == 'submit' ? 'usa-button',
-  button_type == 'reset' ? 'usa-button--secondary',
+  type == 'submit' ? 'bix-button',
+  button_type == 'reset' ? 'bix-button bix-button--unstyled',
   type == 'range' ? 'usa-range',
   time_picker_style == 'html5_time_picker' ? 'width-card-lg is-html5-time-picker',
   form_id == 'search_form' ? 'maxw-card tablet:maxw-mobile-lg',


### PR DESCRIPTION
<!--
  **PR title**

  **Feature PR's**
  - BSD fixes #ISSUE_NO: Brief description
  - BSD-ISSUE_NO: Brief description

  **Releases**
  Release/RELEASE_NO
-->

# Summary

Adds Bixal theme button classes to submit and reset buttons.

| Before | After |
| :----- | :---- |
| ![Image](https://github.com/user-attachments/assets/5fb7802a-84a8-4c1d-8aa9-6aa22151c4ec) |  ![capture-Arc-2025-04-14@2x](https://github.com/user-attachments/assets/e1a6bae6-78c8-4928-a718-eec5d5f1cb11)       |


## Related issue

Closes #427

<!--
  Every pull request should have a related issue.
  If one doesn't exist, create one here:
  https://github.com/Bixal/bixal-site-drupal/issues/new/choose
-->

## Solution

I've added the `bix-button` and `bix-button--unstyled` to `bixal_uswds/templates/form/input.html.twig`.

## Testing and review

1. Visit the login page locally `https://bixalcom.lndo.site/user/login`
2. Verify that the submit button is now styled

<!--
## Dependencies

Dependency updates (if any, uncomment this section).

| Dependency                   | Old      | New     |
| :--------------------------- | :------- | :------ |
| [Updated dependency example] | [1.0.0]  | [1.0.1] |
| [New dependency example]     | --       | [3.0.1] |
| [Removed dependency example] | [2.10.2] | --      |
-->
