### PR TITLE
BSD fixes #435: Update order of compile scripts.

### DIFF
--- a/web/themes/custom/bixal_uswds/gulpfile.js
+++ b/web/themes/custom/bixal_uswds/gulpfile.js
@@ -144,6 +144,7 @@ exports.copyAssets = uswds.copyAssets;
 exports.compileSass = uswds.compileSass;
 exports.compile = series(
   logVersion,
-  parallel(exports.compileSass, uswds.compileIcons, buildJS, uswds.copyAssets),
+  uswds.copyAssets, // Assets need to be moved before compiling and moving icons.
+  parallel(exports.compileSass, uswds.compileIcons, buildJS),
 );
 exports.default = this.compile;

--- a/web/themes/custom/bixal_uswds/gulpfile.js
+++ b/web/themes/custom/bixal_uswds/gulpfile.js
@@ -1,6 +1,6 @@
 const uswds = require("@uswds/compile");
 const { parallel, watch, series, src, dest } = require("gulp");
-const gulp = require("gulp");
+const del = require("del");
 const browsersync = require("browser-sync").create();
 const uglifyes = require("uglify-es");
 const composer = require("gulp-uglify/composer");
@@ -45,7 +45,7 @@ const settings = {
 
 // JS build function.
 function buildJS() {
-  return src(settings.js.src).pipe(uglify()).pipe(gulp.dest(settings.js.dest));
+  return src(settings.js.src).pipe(uglify()).pipe(dest(settings.js.dest));
 }
 
 // Watch changes on JS and twig files and trigger functions at the end.
@@ -121,6 +121,13 @@ function watchSass() {
 }
 // End required to build Sass.
 
+// Remove the compiled assets. This will help show errors early if the build
+// process is broken and the site is simply using the old files.
+function clean() {
+  log(colors.blue, 'Clearing out the dist folder')
+  return del('dist/**', {force:true});
+}
+
 /**
  * Exports
  * Add as many as you need
@@ -144,6 +151,7 @@ exports.copyAssets = uswds.copyAssets;
 exports.compileSass = uswds.compileSass;
 exports.compile = series(
   logVersion,
+  clean,
   uswds.copyAssets, // Assets need to be moved before compiling and moving icons.
   parallel(exports.compileSass, uswds.compileIcons, buildJS),
 );


### PR DESCRIPTION
# Summary

Updated the order of gulp tasks to fix missing directory error.

## Related issue

Closes #435.

<!--
  Every pull request should have a related issue.
  If one doesn't exist, create one here:
  https://github.com/Bixal/bixal-site-drupal/issues/new/choose
-->

## Solution

Matches the init pattern in USWDS compile, where the assets are copied before compiling.

https://github.com/uswds/uswds-compile/blob/cc5f8c7298a1716b67a590f6bcebebdb7a4beaaf/gulpfile.js#L303

## Testing and review

1. Checkout this branch
2. Delete the `bixal_uswds/dist` directory
    ```bash
    rm -rf web/themes/custom/bixal_uswds/dist/
    ```
3. Run lando build node task
    ```bash
    lando build_node
    ```

<!--
## Dependencies

Dependency updates (if any, uncomment this section).

| Dependency                   | Old      | New     |
| :--------------------------- | :------- | :------ |
| [Updated dependency example] | [1.0.0]  | [1.0.1] |
| [New dependency example]     | --       | [3.0.1] |
| [Removed dependency example] | [2.10.2] | --      |
-->
