### PR TITLE
BSD fixes #439: Remove storybook from prod

### DIFF
--- a/.platform/applications.yaml
+++ b/.platform/applications.yaml
@@ -131,7 +131,7 @@ bixalcom:
         npx storybook build --output-dir sb
         rm -r "$PLATFORM_APP_DIR/node_modules"
       else
-        echo "Skipping StoryBook installation.
+        echo "Skipping StoryBook installation."
       fi
 
     # The deploy hook runs after your application has been deployed and started.

--- a/.platform/applications.yaml
+++ b/.platform/applications.yaml
@@ -125,11 +125,11 @@ bixalcom:
       $PLATFORM_APP_DIR/orch/build.sh
 
       # Install storybook into the ./sb directory.
-      if ( [ "${PLATFORM_ENVIRONMENT_TYPE}" != "production" ] ); then
+      if [[ "${PLATFORM_ENVIRONMENT_TYPE}" != "production" ]]; then
         echo "Installing StoryBook"
         npm install
         npx storybook build --output-dir sb
-        rm -r $PLATFORM_APP_DIR/node_modules
+        rm -r "$PLATFORM_APP_DIR/node_modules"
       else
         echo "Skipping StoryBook installation.
       fi

--- a/.platform/applications.yaml
+++ b/.platform/applications.yaml
@@ -125,7 +125,7 @@ bixalcom:
       $PLATFORM_APP_DIR/orch/build.sh
 
       # Install storybook into the ./sb directory.
-      if [[ "${PLATFORM_ENVIRONMENT_TYPE}" != "production" ]]; then
+      if [ "${PLATFORM_ENVIRONMENT_TYPE}" != "production" ]; then
         echo "Installing StoryBook"
         npm install
         npx storybook build --output-dir sb

--- a/.platform/applications.yaml
+++ b/.platform/applications.yaml
@@ -125,9 +125,12 @@ bixalcom:
       $PLATFORM_APP_DIR/orch/build.sh
 
       # Install storybook into the ./sb directory.
-      npm install
-      npx storybook build --output-dir sb
-      rm -r $PLATFORM_APP_DIR/node_modules
+      echo ${PLATFORM_ENVIRONMENT_TYPE}
+      #if ( [ "${PLATFORM_ENVIRONMENT_TYPE}" != "production" ] ); then
+      #  npm install
+      #  npx storybook build --output-dir sb
+      #  rm -r $PLATFORM_APP_DIR/node_modules
+      #fi
 
     # The deploy hook runs after your application has been deployed and started.
     # Code cannot be modified at this point but the database is available.

--- a/.platform/applications.yaml
+++ b/.platform/applications.yaml
@@ -218,6 +218,8 @@ bixalcom:
         passthru: true
         index: ["index.html"]
         allow: true
+        headers:
+          X-Robots-Tag: noindex, nofollow
 
   crons:
     # Run Drupal's cron tasks every 60 minutes.

--- a/.platform/applications.yaml
+++ b/.platform/applications.yaml
@@ -125,12 +125,14 @@ bixalcom:
       $PLATFORM_APP_DIR/orch/build.sh
 
       # Install storybook into the ./sb directory.
-      echo ${PLATFORM_ENVIRONMENT_TYPE}
-      #if ( [ "${PLATFORM_ENVIRONMENT_TYPE}" != "production" ] ); then
-      #  npm install
-      #  npx storybook build --output-dir sb
-      #  rm -r $PLATFORM_APP_DIR/node_modules
-      #fi
+      if ( [ "${PLATFORM_ENVIRONMENT_TYPE}" != "production" ] ); then
+        echo "Installing StoryBook"
+        npm install
+        npx storybook build --output-dir sb
+        rm -r $PLATFORM_APP_DIR/node_modules
+      else
+        echo "Skipping StoryBook installation.
+      fi
 
     # The deploy hook runs after your application has been deployed and started.
     # Code cannot be modified at this point but the database is available.

--- a/README.md
+++ b/README.md
@@ -115,7 +115,8 @@ It's important that you always use `lando composer` or `./composer.sh` instead o
 
 [Storybook preview is available here →](https://www.bixal.com/sb)
 
-This is also available on all other environments.
+> [!NOTE]
+> We have environments for: dev, stage, and prod. They are manually created and require access to Platform.sh.
 
 [Storybook](https://storybook.js.org/) for this project can be found by:
 


### PR DESCRIPTION
<!--
  **PR title**

  **Feature PR's**
  - BSD fixes #ISSUE_NO: Brief description
  - BSD-ISSUE_NO: Brief description

  **Releases**
  Release/RELEASE_NO
-->

# Summary

Removes storybook from being build on production.



## Solution

<!--
A summary of the solution this PR offers.

It can be helpful if we understand:
1. What the solution is,
2. Why this approach was chosen,
3. How you implemented the change, and
4. Possible limitations of this approach and alternate solution paths.
-->

Stop the build process if PLATFORM_ENVIRONMENT_TYPE is production. The /sb/ route is still in place and shows a platform 404 instead of a Drupal one, but I think that's OK. 

## Testing and review

I built this branch here https://feature-bsd-439-remove-pprxtii-tsvj5tw7p3f66.us.platformsh.site/sb/ but we won't be able to test the removal on prod until it's pushed. Unfortunately you can only set one prod type env. You can see that sb is still being built.
