### PR TITLE
BSD fixes #460: Center hero images

### DIFF
--- a/stories/components/hero/hero.scss
+++ b/stories/components/hero/hero.scss
@@ -27,7 +27,7 @@
 // Hero with background image
 // ==========================================================================
 %hero-gradient-overlay {
-  content: '';
+  content: "";
   background-image: radial-gradient(
     circle,
     rgba(0, 0, 0, 0.48) 0%,
@@ -42,7 +42,7 @@
 }
 
 .bix-hero--image-bg {
-  background-position: top;
+  background-position: center;
   background-repeat: no-repeat;
   background-size: cover;
   min-height: 400px;
@@ -111,5 +111,4 @@
       letter-spacing: -2.4px;
     }
   }
-
 }


### PR DESCRIPTION
# Summary

A quick change to hero background images, from position `top` to `center`.

## Related issue

Closes #460.


## Testing and review

| Before | After |
| :----- | :---- |
| ![capture-Arc-2025-06-04@2x](https://github.com/user-attachments/assets/26f8f4ca-8ce2-4ae4-927b-9da8a18f97e9) |       ![capture-Arc-2025-06-04@2x](https://github.com/user-attachments/assets/e1274dfe-0184-425e-a58a-13e5b5fb8854)  |


<!--
## Dependencies

Dependency updates (if any, uncomment this section).

| Dependency                   | Old      | New     |
| :--------------------------- | :------- | :------ |
| [Updated dependency example] | [1.0.0]  | [1.0.1] |
| [New dependency example]     | --       | [3.0.1] |
| [Removed dependency example] | [2.10.2] | --      |
-->
