### PR TITLE
BSD-402: Use alerts for Drupal status messages

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,8 +11,7 @@ The remote environments are hosted in platform.sh. See the `./.platform` directo
 
 Links to environments can be found in [SharePoint 🔒](https://bixal365.sharepoint.com/:x:/s/Dev/ETDXL_cyD11Ahbtub5L-658BuyLzJ9Hky_LmvkkAcDsEZQ?e=wIKXpt).
 
-> [!CAUTION]
-> **HIT REFRESH AFTER CLICKING.** Story book will not load because the basic auth credentials are in the URL.
+> [!CAUTION] > **HIT REFRESH AFTER CLICKING.** Story book will not load because the basic auth credentials are in the URL.
 
 ## Getting Started
 
@@ -34,7 +33,6 @@ The local environment is based on [Drupal Env](https://github.com/mattsqd/drupal
 
 #### Starting/Stopping the Environment
 
-
 **Starting**
 
 For future sessions, you can start lando:
@@ -46,17 +44,16 @@ lando start
 **Stopping**
 
 Run the following command to stop the environment:
+
 ```
 lando stop
 ```
-
 
 You'll be able to visit the local site at: https://bixalcom.lndo.site.
 
 #### Rebuilding / Reinstalling Dependencies
 
 Change something in the `.lando.yml` config and/or you want to re-install front and back end dependencies?
-
 
 **Start Fresh:**
 
@@ -119,7 +116,6 @@ BSD closes #64: Fixed coding standards issues.
 
 More guidance on git branching and commit style in [robo.yml](https://github.com/Bixal/bixal-site-drupal/blob/develop/robo.yml) config.
 
-
 ## Development Commands
 
 ### Installing Drupal with Sample Content
@@ -153,7 +149,6 @@ lando export-content
 
 By default, Lando runs Composer commands within its Docker containers. This often times out, so we recommend using your local Composer instead.
 
-
 ```
 ./composer.sh
 ```
@@ -161,21 +156,22 @@ By default, Lando runs Composer commands within its Docker containers. This ofte
 **Local Composer Setup**
 
 1. Install [homebrew](https://brew.sh/):
-    ```
-    /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
-    ```
+   ```
+   /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
+   ```
 2. Install composer:
-    ```
-    brew install composer
-    ```
 
-    > [!NOTE]
-    > Make sure the installed PHP matches the project version.
+   ```
+   brew install composer
+   ```
+
+   > [!NOTE]
+   > Make sure the installed PHP matches the project version.
+
 3. Set the local to use your composer:
-    ```
-    echo 'BIN_PATH_COMPOSER="composer"' >> .env
-    ```
-
+   ```
+   echo 'BIN_PATH_COMPOSER="composer"' >> .env
+   ```
 
 #### Composer.log Management
 
@@ -195,6 +191,8 @@ Run all the validation commands that the pipelines run without needing to push r
 
 #### Copy storybook to Drupal theme
 
+Use this command to view changes from Storybook components.
+
 ```
 lando build_node
 ```
@@ -202,7 +200,6 @@ lando build_node
 #### Configure Xdebug
 
 https://github.com/mattsqd/drupal-env-lando/wiki/XDebug-(Personal)
-
 
 ## Storybook
 
@@ -222,9 +219,3 @@ Alternatively:
 ```
 
 This should automatically open it in your browser.
-
-### Copy Storybook to Drupal Theme
-
-```
-lando build_node
-```

--- a/stories/assets/styles/global/global.scss
+++ b/stories/assets/styles/global/global.scss
@@ -59,6 +59,9 @@ $font-heading: "novel-pro", Georgia, Times, "Times New Roman", serif;
   // Urgent
   --c-urgent: #{color("orange-warm-70v")};
 
+  // Success
+  --c-success: #{color("green-cool-40v")};
+
   //
   // Fonts
   //

--- a/stories/components/alert/alert.html.twig
+++ b/stories/components/alert/alert.html.twig
@@ -14,8 +14,15 @@
 
 {% set heading_type = heading_type | default("h4") %}
 
+{% set is_important = (variant|default("")) in ['urgent', 'warning', 'error'] %}
+
 {% if attributes is empty %}
   {% set attributes = create_attribute() %}
+{% endif %}
+
+{# For accessibility, highlight important alerts. #}
+{% if is_important %}
+  {% set attributes = attributes.setAttribute("role", "alert") %}
 {% endif %}
 
 {% set alert_classes = [
@@ -35,10 +42,10 @@
       {{ title }}
     </{{ heading_type }}>
   {% endif %}
-  {% if text %}
     <div class="bix-alert__text">
-      {{ text }}
+      {% block body %}
+        {% if text %}{{ text }}{% endif %}
+      {% endblock %}
     </div>
-  {% endif %}
   </div>
 </div>

--- a/stories/components/alert/alert.html.twig
+++ b/stories/components/alert/alert.html.twig
@@ -4,7 +4,7 @@
   *
   * Available variables:
   * - variant: String alert type: info, error, warning.
-  * - icon: String alert icon from USWDS: info, error, warning.
+  * - icon: String alert icon from USWDS: info, error, warning, and success.
   * - heading_type: Optional string for the type of header (h1-h6).
   * - title: Optional string for the alert header.
   * - text: A string of the alert body text.
@@ -25,16 +25,13 @@
 
 <div{{ attributes.addClass(alert_classes) }}>
   <div class="bix-alert__body">
-
-
-  {% if title %}
-    <{{ heading_type }} class="bix-alert__heading">
-    {% if icon %}
+  {% if icon %}
     <span class="bix-alert__icon">
       {{ source(icon) }}
     </span>
-    {% endif %}
-
+  {% endif %}
+  {% if title %}
+    <{{ heading_type }} class="bix-alert__heading">
       {{ title }}
     </{{ heading_type }}>
   {% endif %}

--- a/stories/components/alert/alert.html.twig
+++ b/stories/components/alert/alert.html.twig
@@ -8,6 +8,10 @@
   * - heading_type: Optional string for the type of header (h1-h6).
   * - title: Optional string for the alert header.
   * - text: A string of the alert body text.
+  *
+  * Accessibility
+  * If the alert is important (e.g., "urgent", "warning", "error"), we set a `role="alert"` for screen readers.
+  *
 **/
 #}
 
@@ -33,7 +37,8 @@
 <div{{ attributes.addClass(alert_classes) }}>
   <div class="bix-alert__body">
   {% if icon %}
-    <span class="bix-alert__icon">
+    {# Icon is hidden because its decorative. #}
+    <span class="bix-alert__icon" aria-hidden="true">
       {{ source(icon) }}
     </span>
   {% endif %}
@@ -44,6 +49,17 @@
   {% endif %}
     <div class="bix-alert__text">
       {% block body %}
+        {#
+        /**
+          * You can override the body to display a list of messages.
+          *
+          * @example
+          * {% embed '@components/alert/alert.html.twig' with { variant: 'info' } %}
+          *   {% block body %}<ul>...a bunch of list items</ul>{% endblock %}
+          * {% endembed %}
+          *
+        **/
+        #}
         {% if text %}{{ text }}{% endif %}
       {% endblock %}
     </div>

--- a/stories/components/alert/alert.scss
+++ b/stories/components/alert/alert.scss
@@ -9,8 +9,19 @@
   border-left: 4px solid var(--_alert-color);
 
   &__body {
-    padding: units(1.5) units(2.5);
-    padding-left: units(5);
+    padding: units(1) units(2.5);
+    padding-inline-start: units(5);
+    position: relative;
+  }
+
+  &__icon {
+    fill: var(--_alert-color);
+    position: absolute;
+    z-index: 1;
+    margin-inline-start: -1.9rem;
+    margin-block-start: 0.25rem;
+    width: units(2.5);
+    height: units(2.5);
   }
 }
 
@@ -24,4 +35,8 @@
 
 .bix-alert--error {
   --alert-color: var(--c-error);
+}
+
+.bix-alert--success {
+  --alert-color: var(--c-success);
 }

--- a/stories/components/alert/alert.scss
+++ b/stories/components/alert/alert.scss
@@ -23,6 +23,10 @@
     width: units(2.5);
     height: units(2.5);
   }
+
+  &:where(:not(:first-child)) {
+    margin-block-start: units(1);
+  }
 }
 
 .bix-alert--info {

--- a/stories/components/alert/alert.stories.js
+++ b/stories/components/alert/alert.stories.js
@@ -3,6 +3,7 @@ import "./alert.scss";
 import infoIcon from "@uswds/uswds/img/usa-icons/info_outline.svg";
 import warningIcon from "@uswds/uswds/img/usa-icons/warning.svg";
 import errorIcon from "@uswds/uswds/img/usa-icons/error_outline.svg";
+import successIcon from "@uswds/uswds/img/usa-icons/check_circle_outline.svg";
 
 export default {
   title: "Components/Alert",
@@ -55,5 +56,14 @@ export const Error = {
     ...defaultContent,
     icon: errorIcon,
     variant: "error",
+  },
+};
+
+export const Success = {
+  args: {
+    title: null,
+    text: "Thank you for the submission!",
+    icon: successIcon,
+    variant: "success",
   },
 };

--- a/web/themes/custom/bixal_uswds/src/sass/drupal-system/system.scss
+++ b/web/themes/custom/bixal_uswds/src/sass/drupal-system/system.scss
@@ -21,25 +21,30 @@
 //Missing tabs for d10 update
 .tabs.tabs--primary {
   .tabs__link {
-    @include u-bg('gray-warm-5');
+    @include u-bg("gray-warm-5");
     @include u-border("1px", "solid", "gray-warm-10");
     color: #666;
-    @include u-display('block');
-    @include u-font-weight('bold');
+    @include u-display("block");
+    @include u-font-weight("bold");
     font-size: 15px;
     @include u-padding-x(2);
     @include u-padding-y(1);
-    @include u-text-align('center');
+    @include u-text-align("center");
     text-decoration: none;
     transition: color 0.3s;
-    &:hover  {
+    &:hover {
       background-color: #e5e5e5;
       text-decoration: underline;
-  }
+    }
     &.is-active {
       background-color: color("gray-50");
       @include u-border("1px", "solid", "gray-50");
       color: color("white");
     }
   }
+}
+
+// Status messages
+.drupal-status-messages {
+  margin-block: units(2);
 }

--- a/web/themes/custom/bixal_uswds/templates/misc/status-messages.html.twig
+++ b/web/themes/custom/bixal_uswds/templates/misc/status-messages.html.twig
@@ -21,46 +21,48 @@
 #}
 
 <div data-drupal-messages class="drupal-status-messages">
-  {% block messages %}
-    {% for type, messages in message_list %}
-      {% set classes = [
-        'messages',
-        'messages--' ~ type,
-        'bix-alert',
-        'bix-alert--' ~ type,
-        type == 'status' ? 'bix-alert--success',
-      ] %}
+  <div class="bix-container">
+    {% block messages %}
+      {% for type, messages in message_list %}
+        {% set classes = [
+          'messages',
+          'messages--' ~ type,
+          'bix-alert',
+          'bix-alert--' ~ type,
+          type == 'status' ? 'bix-alert--success',
+        ] %}
 
-      {% if style == 'urgent' %}
-        {% set icon = directory ~ '/dist/assets/img/usa-icons/error_outline.svg' %}
-      {% elseif style == 'warning' %}
-        {% set icon = directory ~ '/dist/assets/img/usa-icons/warning.svg' %}
-      {% elseif style == 'status' %}
-        {% set icon = directory ~ '/dist/assets/img/usa-icons/check_circle_outline.svg' %}
-      {% else %}
-        {% set icon = directory ~ '/dist/assets/img/usa-icons/info_outline.svg' %}
-      {% endif %}
+        {% if style == 'urgent' %}
+          {% set icon = directory ~ '/dist/assets/img/usa-icons/error_outline.svg' %}
+        {% elseif style == 'warning' %}
+          {% set icon = directory ~ '/dist/assets/img/usa-icons/warning.svg' %}
+        {% elseif style == 'status' %}
+          {% set icon = directory ~ '/dist/assets/img/usa-icons/check_circle_outline.svg' %}
+        {% else %}
+          {% set icon = directory ~ '/dist/assets/img/usa-icons/info_outline.svg' %}
+        {% endif %}
 
-      {% embed "@components/alert/alert.html.twig" with {
-        variant: type,
-        additional_classes: classes,
-        title: status_headings[type],
-        icon: icon
-      } %}
-        {% block body %}
-          {# Show a list of messages or a single one. #}
-          {% if messages|length > 1 %}
-            <ul class="messages__list bix-list">
-              {% for message in messages %}
-                <li class="messages__item">{{ message }}</li>
-              {% endfor %}
-            </ul>
-          {% else %}
-            {{ messages|first }}
-          {% endif %}
+        {% embed "@components/alert/alert.html.twig" with {
+          variant: type,
+          additional_classes: classes,
+          title: status_headings[type],
+          icon: icon
+        } %}
+          {% block body %}
+            {# Show a list of messages or a single one. #}
+            {% if messages|length > 1 %}
+              <ul class="messages__list bix-list">
+                {% for message in messages %}
+                  <li class="messages__item">{{ message }}</li>
+                {% endfor %}
+              </ul>
+            {% else %}
+              {{ messages|first }}
+            {% endif %}
 
-        {% endblock %}
-      {% endembed %}
-    {% endfor %}
-  {% endblock messages %}
+          {% endblock %}
+        {% endembed %}
+      {% endfor %}
+    {% endblock messages %}
+  </div>
 </div>

--- a/web/themes/custom/bixal_uswds/templates/misc/status-messages.html.twig
+++ b/web/themes/custom/bixal_uswds/templates/misc/status-messages.html.twig
@@ -32,11 +32,11 @@
           type == 'status' ? 'bix-alert--success',
         ] %}
 
-        {% if style == 'urgent' %}
+        {% if type == 'urgent' %}
           {% set icon = directory ~ '/dist/assets/img/usa-icons/error_outline.svg' %}
-        {% elseif style == 'warning' %}
+        {% elseif type == 'warning' %}
           {% set icon = directory ~ '/dist/assets/img/usa-icons/warning.svg' %}
-        {% elseif style == 'status' %}
+        {% elseif type == 'status' %}
           {% set icon = directory ~ '/dist/assets/img/usa-icons/check_circle_outline.svg' %}
         {% else %}
           {% set icon = directory ~ '/dist/assets/img/usa-icons/info_outline.svg' %}

--- a/web/themes/custom/bixal_uswds/templates/misc/status-messages.html.twig
+++ b/web/themes/custom/bixal_uswds/templates/misc/status-messages.html.twig
@@ -19,49 +19,48 @@
  *   - class: HTML classes.
  */
 #}
-<div data-drupal-messages>
+
+<div data-drupal-messages class="drupal-status-messages">
   {% block messages %}
     {% for type, messages in message_list %}
       {% set classes = [
         'messages',
         'messages--' ~ type,
-        'usa-alert',
-        'usa-alert--' ~ type,
-        type == 'status' ? 'usa-alert--success',
+        'bix-alert',
+        'bix-alert--' ~ type,
+        type == 'status' ? 'bix-alert--success',
       ] %}
 
-      <div role="contentinfo"
-           aria-label="{{ status_headings[type] }}"{{ attributes.addClass(classes)|without('role', 'aria-label') }}>
-        {% if type == 'error' %}
-        <div role="alert">
-          {% endif %}
+      {% if style == 'urgent' %}
+        {% set icon = directory ~ '/dist/assets/img/usa-icons/error_outline.svg' %}
+      {% elseif style == 'warning' %}
+        {% set icon = directory ~ '/dist/assets/img/usa-icons/warning.svg' %}
+      {% elseif style == 'status' %}
+        {% set icon = directory ~ '/dist/assets/img/usa-icons/check_circle_outline.svg' %}
+      {% else %}
+        {% set icon = directory ~ '/dist/assets/img/usa-icons/info_outline.svg' %}
+      {% endif %}
 
-          {% if status_headings[type] %}
-            <h2 class="visually-hidden usa-alert__heading">{{ status_headings[type] }}</h2>
-          {% endif %}
-
+      {% embed "@components/alert/alert.html.twig" with {
+        variant: type,
+        additional_classes: classes,
+        title: status_headings[type],
+        icon: icon
+      } %}
+        {% block body %}
+          {# Show a list of messages or a single one. #}
           {% if messages|length > 1 %}
-          <div class="usa-alert__body">
-            <ul class="messages__list usa-list margin-top-0">
+            <ul class="messages__list bix-list">
               {% for message in messages %}
                 <li class="messages__item">{{ message }}</li>
               {% endfor %}
             </ul>
-          </div>
-
           {% else %}
-
-            <div class="usa-alert__body">
-              {{ messages|first }}
-            </div>
+            {{ messages|first }}
           {% endif %}
 
-          {% if type == 'error' %}
-        </div>
-        {% endif %}
-      </div>
-      {# Remove type specific classes. #}
-      {% set attributes = attributes.removeClass(classes) %}
+        {% endblock %}
+      {% endembed %}
     {% endfor %}
   {% endblock messages %}
 </div>


### PR DESCRIPTION
# Summary

Adds a success alert variant and Drupal status messages now use Bixal Alert component.

| Before | After |
| :----- | :---- |
| ![capture-KEu9OrXe-2025-09-03](https://github.com/user-attachments/assets/681fe62f-dadd-4732-a926-9ec9864961f8) |   ![capture-8ZwiYISb-2025-09-03](https://github.com/user-attachments/assets/f308c26d-bf37-47d4-a6a4-41c0908ae6a2)     |


## Related issue

Closes #402

## Solution

### Status messages

- Replaces USA Alert with Bixal Alert
- Adds a wrapper class to contain alerts

### Bix alert

- Improved a11y by setting `role="alert"` to urgent, warning, and error variants
- Allows custom body block markup instead of plain text only
- Adds success variant
- Adjustments to icon positioning and spacing

### Other

- Added a new success variant in Storybook
- Updated README
- Used logical properties to replace `margin-left/right/etc.` to better support other languages

## Testing and review

- While logged in, submit a form
- You should see the new status messages and warnings should have `role="alert"`
- Run `npm run storybook:local` and visit Alert Success variant
- There shouldn't be any visual issues

<!--
## Dependencies

Dependency updates (if any, uncomment this section).

| Dependency                   | Old      | New     |
| :--------------------------- | :------- | :------ |
| [Updated dependency example] | [1.0.0]  | [1.0.1] |
| [New dependency example]     | --       | [3.0.1] |
| [Removed dependency example] | [2.10.2] | --      |
-->
