### PR TITLE
BSD-506: button links

### DIFF
--- a/stories/components/button/button.html.twig
+++ b/stories/components/button/button.html.twig
@@ -33,7 +33,7 @@
 ] | merge(additional_classes | default([])) %}
 
 {% set button_inner %}
-  {{ label | default((variant | capitalize | default("Default")) ~ " button")}}
+  {{ label | default("Learn more")}}
   {% if has_icon %}{{ source(icon_path) }}{% endif %}
 {% endset %}
 

--- a/stories/components/section/section.html.twig
+++ b/stories/components/section/section.html.twig
@@ -61,11 +61,16 @@
     {{ body }}
 
     {% block footer %}
-      {% if cta.href %}
-        <div
-          class="bix-section__footer">
-          {# Avoid button inheriting section data. #}
-          {% include "@components/button/button.html.twig" with cta only %}
+      {% if cta %}
+        <div class="bix-section__footer">
+          {# If this is a render element, just render it. #}
+          {% if cta['#theme'] %}
+            {{ cta }}
+            {# If this is an array of properties, ie storybook, use a component. #}
+          {% elseif cta.href %}
+            {# Avoid button inheriting section data. #}
+            {% include "@components/button/button.html.twig" with cta only %}
+          {% endif %}
         </div>
       {% endif %}
     {% endblock %}

--- a/stories/components/section/section.html.twig
+++ b/stories/components/section/section.html.twig
@@ -26,14 +26,14 @@
 ] | merge(additional_classes | default([])) %}
 
 <section
-    {{ attributes.addClass(section_classes) }} {% if image %} style="background-image: url('{{ image }}')" {% endif %}>
+  {{ attributes.addClass(section_classes) }} {% if image %} style="background-image: url('{{ image }}')" {% endif %}>
   {{ content.contextual_links }}
   {#
-    /**
-      ? The `bix-container` can appear *without* content, for sections like homepage flip grids.
-      ? A side effect of this is that `bix-container` can appear empty on image only sections, ex: above "Careers - How we work"
-    **/
-    #}
+  /**
+    ? The `bix-container` can appear *without* content, for sections like homepage flip grids.
+    ? A side effect of this is that `bix-container` can appear empty on image only sections, ex: above "Careers - How we work"
+  **/
+  #}
   <div class="bix-container">
     {% block header %}
       {% if prefix_below %}
@@ -63,7 +63,7 @@
     {% block footer %}
       {% if cta.href %}
         <div
-            class="bix-section__footer">
+          class="bix-section__footer">
           {# Avoid button inheriting section data. #}
           {% include "@components/button/button.html.twig" with cta only %}
         </div>

--- a/stories/components/section/section.html.twig
+++ b/stories/components/section/section.html.twig
@@ -61,7 +61,7 @@
     {{ body }}
 
     {% block footer %}
-      {% if cta.label %}
+      {% if cta.href %}
         <div
             class="bix-section__footer">
           {# Avoid button inheriting section data. #}

--- a/web/themes/custom/bixal_uswds/templates/paragraphs/paragraph--button.html.twig
+++ b/web/themes/custom/bixal_uswds/templates/paragraphs/paragraph--button.html.twig
@@ -47,12 +47,9 @@
 
 {% block paragraph %}
   {% include '@components/button/button.html.twig' with {
-      'href': content.field_link.0['#url'].uri,
-      'title': content.field_link.0['#title'],
-      'has_icon': content.field_has_icon['#items'].getString(),
-      'modifier': content.field_modifier.value ? 'bix-button--inverse' : '',
-
-      
+      'href': content.field_link['#items']|first.getUrl().toString(),
+      'label': content.field_link['#items']|first.getTitle(),
+      'icon': content.field_icon['#items']|first.getString(),
+      'variant': content.field_button_variant['#items']|first.getString(),
     } %}
-
 {% endblock paragraph %}

--- a/web/themes/custom/bixal_uswds/templates/paragraphs/paragraph--button.html.twig
+++ b/web/themes/custom/bixal_uswds/templates/paragraphs/paragraph--button.html.twig
@@ -46,10 +46,12 @@
 ] %}
 
 {% block paragraph %}
-  {% include '@components/button/button.html.twig' with {
-      'href': content.field_link['#items']|first.getUrl().toString(),
-      'label': content.field_link['#items']|first.getTitle(),
-      'icon': content.field_icon['#items']|first.getString(),
-      'variant': content.field_button_variant['#items']|first.getString(),
-    } %}
+  {% if content.field_link['#items']|first.getUrl().toString() %}
+    {% include '@components/button/button.html.twig' with {
+        'href': content.field_link['#items']|first.getUrl().toString(),
+        'label': content.field_link['#items']|first.getTitle(),
+        'icon': content.field_icon['#items']|first.getString(),
+        'variant': content.field_button_variant['#items']|first.getString(),
+      } %}
+  {% endif %}
 {% endblock paragraph %}

--- a/web/themes/custom/bixal_uswds/templates/paragraphs/paragraph--section.html.twig
+++ b/web/themes/custom/bixal_uswds/templates/paragraphs/paragraph--section.html.twig
@@ -53,20 +53,6 @@
 
 {% set cta = [] %}
 
-
-{% set button_paragraph = content.field_button.0['#paragraph'] %}
-{% set link_field = button_paragraph.field_link %}
-{% set href = link_field|first.getUrl().toString() %}
-{% if href %}
-  {% set cta = cta|merge(
-    { 'href': href,
-      'label': link_field|first.getTitle(),
-      'icon': button_paragraph.field_icon|first.getString(),
-      'variant': button_paragraph.field_button_variant|first.getString()
-    }
-  ) %}
-{% endif %}
-
 {% block paragraph %}
   {% include '@components/section/section.html.twig' with {
     'title': content.field_title | field_value,
@@ -74,7 +60,7 @@
     'description': content.field_description | field_value,
     'body': content.field_nested_paragraphs | field_value,
     'center_content': content.field_center_content.0['#markup'],
-    'cta': cta,
+    'cta': content.field_button.0['#paragraph'].field_link|first.getUrl().toString() ? drupal_entity('paragraph', content.field_button.0['#paragraph'].id()) : {},
     'image': bg_image
   } %}
 

--- a/web/themes/custom/bixal_uswds/templates/paragraphs/paragraph--section.html.twig
+++ b/web/themes/custom/bixal_uswds/templates/paragraphs/paragraph--section.html.twig
@@ -53,22 +53,19 @@
 
 {% set cta = [] %}
 
-{% set href %}
-  {% if content.field_button.0['#paragraph'].field_link is not empty %}
-    {% if content.field_button.0['#paragraph'].field_link.0.url.external %}
-      {{ content.field_button.0['#paragraph'].field_link.uri }}
-    {% else %}
-      {{ path(content.field_button.0['#paragraph'].field_link.0.url.routeName, content.field_button.0['#paragraph'].field_link.0.url.routeParameters) }}
-    {% endif %}
-  {% endif %}
-{% endset %}
-{% set cta = cta|merge(
-  { 'href': href,
-    'label': content.field_button.0['#paragraph'].field_link.title,
-    'icon': content.field_button.0['#paragraph'].field_icon.0.value,
-    'variant': content.field_button.0['#paragraph'].field_button_variant.0.value
-  }
-) %}
+
+{% set button_paragraph = content.field_button.0['#paragraph'] %}
+{% set link_field = button_paragraph.field_link %}
+{% set href = link_field|first.getUrl().toString() %}
+{% if href %}
+  {% set cta = cta|merge(
+    { 'href': href,
+      'label': link_field|first.getTitle(),
+      'icon': button_paragraph.field_icon|first.getString(),
+      'variant': button_paragraph.field_button_variant|first.getString()
+    }
+  ) %}
+{% endif %}
 
 {% block paragraph %}
   {% include '@components/section/section.html.twig' with {


### PR DESCRIPTION
<!--
  **PR title**

  **Feature PR's**
  - BSD fixes #ISSUE_NO: Brief description
  - BSD-ISSUE_NO: Brief description

  **Releases**
  Release/RELEASE_NO
-->

# Summary

When URLs were setting on the button field of section paragraphs if they were internal links, it would break.
I made it similar to how the button nested paragraph is done.

## Related issue

Closes #286

<!--
  Every pull request should have a related issue.
  If one doesn't exist, create one here:
  https://github.com/Bixal/bixal-site-drupal/issues/new/choose
-->

## Solution

The API we were using to retrieve links for buttons diverged. I made them very similar.
I've also made it so that label is not required for the CTA. For both CTA and button paragraph, if you don't set link text, it will be 'Learn more'.

<!--
A summary of the solution this PR offers.

It can be helpful if we understand:
1. What the solution is,
2. Why this approach was chosen,
3. How you implemented the change, and
4. Possible limitations of this approach and alternate solution paths.
-->

## Testing and review

This was very sneaky. The easiest way to test this is to create a new landing page, then go into the 'Main Content'.
What was different was the 'Button' field on section vs the 'Nested Paragraphs (Body) -> Button paragraph'.
In nested paragraphs body, add a 'Button' paragraph.
At the bottom of 'Section', edit the 'Button' field (which is also a paragraphs confusingly).
For both these items, try all combinations of fields and also entering a URL like 'https://google.com' vs autocompleting an internal page.
If URL is entered, the button should show.

<!--
How to test this work.

1. Describe the tests that you ran to verify your changes
2. Provide instructions to reproduce
3. Clarify the type of feedback you are looking for
-->

<img width="1197" height="1062" alt="image" src="https://github.com/user-attachments/assets/24454c5c-d130-43a7-96a0-d55d21ddc19c" />

These are the two items we're working with.