### PR TITLE
BSD-509: Add description list image styles

### DIFF
--- a/config/sync/core.entity_view_display.media.image.description_list.yml
+++ b/config/sync/core.entity_view_display.media.image.description_list.yml
@@ -1,0 +1,38 @@
+uuid: bf2994ff-040a-412b-85ad-a1b8cc6065c7
+langcode: en
+status: true
+dependencies:
+  config:
+    - core.entity_view_mode.media.description_list
+    - field.field.media.image.field_media_image
+    - image.style.description_list
+    - media.type.image
+  module:
+    - svg_image
+id: media.image.description_list
+targetEntityType: media
+bundle: image
+mode: description_list
+content:
+  field_media_image:
+    type: image
+    label: visually_hidden
+    settings:
+      image_link: ''
+      image_style: description_list
+      image_loading:
+        attribute: lazy
+      svg_attributes:
+        width: null
+        height: null
+      svg_render_as_image: true
+    third_party_settings: {  }
+    weight: 0
+    region: content
+hidden:
+  created: true
+  langcode: true
+  name: true
+  search_api_excerpt: true
+  thumbnail: true
+  uid: true

--- a/config/sync/core.entity_view_display.paragraph.description_list.default.yml
+++ b/config/sync/core.entity_view_display.paragraph.description_list.default.yml
@@ -7,10 +7,8 @@ dependencies:
     - field.field.paragraph.description_list.field_description_list_variant
     - field.field.paragraph.description_list.field_image
     - field.field.paragraph.description_list.field_title
-    - image.style.description_list
     - paragraphs.paragraphs_type.description_list
   module:
-    - media
     - options
 id: paragraph.description_list.default
 targetEntityType: paragraph
@@ -33,13 +31,11 @@ content:
     weight: 3
     region: content
   field_image:
-    type: media_thumbnail
+    type: entity_reference_entity_view
     label: hidden
     settings:
-      image_link: ''
-      image_style: description_list
-      image_loading:
-        attribute: lazy
+      view_mode: description_list
+      link: false
     third_party_settings: {  }
     weight: 2
     region: content

--- a/config/sync/core.entity_view_display.paragraph.description_list.default.yml
+++ b/config/sync/core.entity_view_display.paragraph.description_list.default.yml
@@ -7,8 +7,10 @@ dependencies:
     - field.field.paragraph.description_list.field_description_list_variant
     - field.field.paragraph.description_list.field_image
     - field.field.paragraph.description_list.field_title
+    - image.style.description_list
     - paragraphs.paragraphs_type.description_list
   module:
+    - media
     - options
 id: paragraph.description_list.default
 targetEntityType: paragraph
@@ -31,11 +33,13 @@ content:
     weight: 3
     region: content
   field_image:
-    type: entity_reference_entity_view
+    type: media_thumbnail
     label: hidden
     settings:
-      view_mode: description_list
-      link: false
+      image_link: ''
+      image_style: description_list
+      image_loading:
+        attribute: lazy
     third_party_settings: {  }
     weight: 2
     region: content

--- a/config/sync/image.style.description_list.yml
+++ b/config/sync/image.style.description_list.yml
@@ -1,0 +1,15 @@
+uuid: b1c76ad5-7d81-40e9-8137-f027106df677
+langcode: en
+status: true
+dependencies: {  }
+name: description_list
+label: 'Description list'
+effects:
+  ad6463b4-e449-4a12-8a19-37d1c56af210:
+    uuid: ad6463b4-e449-4a12-8a19-37d1c56af210
+    id: image_scale_and_crop
+    weight: 1
+    data:
+      width: 439
+      height: 222
+      anchor: center-center

--- a/config/sync/image.style.description_list.yml
+++ b/config/sync/image.style.description_list.yml
@@ -3,7 +3,7 @@ langcode: en
 status: true
 dependencies: {  }
 name: description_list
-label: 'Description list'
+label: 'Description list (439×222)'
 effects:
   ad6463b4-e449-4a12-8a19-37d1c56af210:
     uuid: ad6463b4-e449-4a12-8a19-37d1c56af210


### PR DESCRIPTION
<!--
  **PR title**

  **Feature PR's**
  - BSD fixes #ISSUE_NO: Brief description
  - BSD-ISSUE_NO: Brief description

  **Releases**
  Release/RELEASE_NO
-->

# Summary

Adds an image style to the Description List paragraph w/ lazy loading.

> [!NOTE]
> I didn't add a responsive image style because this is small enough that it's not needed yet. Open to adding in the future.


## Related issue

Closes #509.

<!--
  Every pull request should have a related issue.
  If one doesn't exist, create one here:
  https://github.com/Bixal/bixal-site-drupal/issues/new/choose
-->

## Solution

Adds a dedicated image style to Description List components to make sure it renders consistently, avoids blurring or loading more than we need. 

## Major changes

> [!NOTE]
> This still includes lazy loading for performance.

**New image style** 
Added `description_list` image style with scale and crop at `439x222`, which is smaller than the previous `480x222` being loaded.

![capture-rc8M4fcY-2025-10-28@2x](https://github.com/user-attachments/assets/35ac9826-43e7-4d8c-a7e8-8c5369c3ef74)


```bash
https://bixalcom.lndo.site/admin/config/media/image-styles/manage/description_list?destination=/admin/config/media/image-styles
```

### Results

| Before | After |
| :----- | :---- |
| ![dl-before](https://github.com/user-attachments/assets/bf02647a-caca-4689-b2fe-c70ebb4c3301) | ![dl-after](https://github.com/user-attachments/assets/1eabc24f-fe44-49eb-ad45-dcba37a30f4e)         |

#### Image sizes

Image name | Before | After |
| :----- | :----- | :---- |
| health | 11.1KB | 9.3KB |
| business | 25.0KB | 21.4 KB |
| other | 18.9 KB | 16.1 KB |

**Total:** 8.2KB


<!--
A summary of the solution this PR offers.

It can be helpful if we understand:
1. What the solution is,
2. Why this approach was chosen,
3. How you implemented the change, and
4. Possible limitations of this approach and alternate solution paths.
-->

## Testing and review

1. Import the config
    ```bash
    lando drush cim -y
    ```
2. Verify that the homepage description list renders the new image size, `439x222`.
3. Confirm its being lazy loaded (inspect and look for `loading="lazy"`.

<!--
## Dependencies

Dependency updates (if any, uncomment this section).

| Dependency                   | Old      | New     |
| :--------------------------- | :------- | :------ |
| [Updated dependency example] | [1.0.0]  | [1.0.1] |
| [New dependency example]     | --       | [3.0.1] |
| [Removed dependency example] | [2.10.2] | --      |
-->
