### PR TITLE
BSD fixes #529: Don't allow the responsive image template to link to the media ever

### DIFF
--- a/web/themes/custom/bixal_uswds/templates/media/responsive-image-formatter.html.twig
+++ b/web/themes/custom/bixal_uswds/templates/media/responsive-image-formatter.html.twig
@@ -1,0 +1,17 @@
+{#
+/**
+ * @file
+ * Theme override to display a formatted responsive image field.
+ *
+ * Available variables:
+ * - responsive_image: A collection of responsive image data.
+ * - url: An optional URL the image can be linked to.
+ *
+ * @see template_preprocess_responsive_image_formatter()
+ */
+#}
+{#{% if url %}
+  <a href="{{ url }}">{{ responsive_image }}</a>
+{% else %}#}
+  {{ responsive_image }}
+{#{% endif %}#}


### PR DESCRIPTION

<!--
  **PR title**

  **Feature PR's**
  - BSD fixes #ISSUE_NO: Brief description
  - BSD-ISSUE_NO: Brief description

  **Releases**
  Release/RELEASE_NO
-->

# Summary

With the change to add responsive images to the front end, the default template put a link to the media item. This makes no sense for the front end, override this in our theme.

## Related issue

Closes #529

<!--
  Every pull request should have a related issue.
  If one doesn't exist, create one here:
  https://github.com/Bixal/bixal-site-drupal/issues/new/choose
-->

## Solution

Override template to never print URL.
<!--
A summary of the solution this PR offers.

It can be helpful if we understand:
1. What the solution is,
2. Why this approach was chosen,
3. How you implemented the change, and
4. Possible limitations of this approach and alternate solution paths.
-->

## Testing and review

Visit /blogs. Ensure that each blog teaser links only to the blog post, not the media.

<!--
How to test this work.

1. Describe the tests that you ran to verify your changes
2. Provide instructions to reproduce
3. Clarify the type of feedback you are looking for
-->

<!--
## Dependencies

Dependency updates (if any, uncomment this section).

| Dependency                   | Old      | New     |
| :--------------------------- | :------- | :------ |
| [Updated dependency example] | [1.0.0]  | [1.0.1] |
| [New dependency example]     | --       | [3.0.1] |
| [Removed dependency example] | [2.10.2] | --      |
-->
