### PR TITLE
BSD-543: Add issue types to templates and create a task template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -4,6 +4,7 @@ about: Create a report to help us improve
 title: "bixal-site-drupal - bug: <short_description>"
 labels: ["bug", "needs triage"]
 assignees: ""
+type: bug
 ---
 
 ## Describe the bug

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -4,6 +4,7 @@ about: Suggest an idea for this project
 title: "bixal-site-drupal - feature request: <short_description>"
 labels: ["enhancement", "needs triage"]
 assignees: ""
+type: feature
 ---
 
 ## Summary

--- a/.github/ISSUE_TEMPLATE/task.md
+++ b/.github/ISSUE_TEMPLATE/task.md
@@ -1,0 +1,45 @@
+---
+name: Task
+about: A clear, focused piece of work
+title: "bixal-site-drupal - task: <short_description>"
+labels: ["task", "needs triage"]
+assignees: ""
+type: task
+---
+
+## Summary
+
+What needs to be done and why.
+
+## Acceptance criteria
+
+Define what "done" looks like for this task:
+
+- [ ] Criterion 1
+- [ ] Criterion 2
+- [ ] Criterion 3
+
+## Technical details
+
+Provide any technical context, approach, or implementation notes:
+
+- Files/modules affected:
+- Approach:
+- Dependencies:
+
+<!--
+## Dependencies
+
+List any blockers or related issues:
+
+- Blocked by: #
+- Related to: #
+-->
+
+## Alternatives considered
+
+A clear and concise description of any alternative solutions or features you've considered.
+
+## Additional context
+
+Add any other context, screenshots, mockups, or links about the task here.


### PR DESCRIPTION
<!--
  **PR title**

  **Feature PR's**
  - BSD fixes #ISSUE_NO: Brief description
  - BSD-ISSUE_NO: Brief description

  **Releases**
  Release/RELEASE_NO
-->

# Summary

Add issue types to existing templates and create a new task issue template.

## Related issue

Closes #543

<!--
  Every pull request should have a related issue.
  If one doesn't exist, create one here:
  https://github.com/Bixal/bixal-site-drupal/issues/new/choose
-->

## Solution

Standardize GitHub issue templates with explicit types and a new task template.

<!--
A summary of the solution this PR offers.

It can be helpful if we understand:
1. What the solution is,
2. Why this approach was chosen,
3. How you implemented the change, and
4. Possible limitations of this approach and alternate solution paths.
-->

## Testing and review

Once merged, we should see these types set automatically on issue creation:
![capture-EIWpBN2h-2026-01-16@2x](https://github.com/user-attachments/assets/eaffa557-70bc-45b6-b62d-ffa2146618b2)


<!--
## Dependencies

Dependency updates (if any, uncomment this section).

| Dependency                   | Old      | New     |
| :--------------------------- | :------- | :------ |
| [Updated dependency example] | [1.0.0]  | [1.0.1] |
| [New dependency example]     | --       | [3.0.1] |
| [Removed dependency example] | [2.10.2] | --      |
-->
