### PR TITLE
BSD fixes #581: Fixed image sizes of accrediation images.

### DIFF
--- a/web/themes/custom/bixal_uswds/php-includes/media.inc
+++ b/web/themes/custom/bixal_uswds/php-includes/media.inc
@@ -39,3 +39,18 @@ function bixal_uswds_theme_suggestions_media_alter(&$suggestions, array $vars): 
     }
   }
 }
+
+/**
+ * Implements hook_preprocess_image().
+ */
+function bixal_uswds_preprocess_image(&$variables) {
+  // SVGs do not get a height and width, unset empty width and height so empty
+  // attributes are not used.
+  if (str_ends_with($variables['uri'] ?? '', '.svg')) {
+    foreach (['width', 'height'] as $attribute) {
+      if (empty($variables['attributes'][$attribute])) {
+        unset($variables['attributes'][$attribute]);
+      }
+    }
+  }
+}

--- a/web/themes/custom/bixal_uswds/php-includes/paragraphs.inc
+++ b/web/themes/custom/bixal_uswds/php-includes/paragraphs.inc
@@ -180,6 +180,10 @@ function bixal_uswds_preprocess_paragraph(&$vars) {
         // Create a render array of the image and add the URL or width from the
         // the other fields.
         $image_field_render_array = $image_field->view();
+        // Default the height and width to empty so it takes it's full space
+        // if not given. Very important if this is an SVG.
+        $image_field_render_array[0]['#attributes']['height'] = '';
+        $image_field_render_array[0]['#attributes']['width'] = '';
         $width_field = $paragraph->get('field_width');
         if (!$width_field->isEmpty()) {
           $width = $width_field->getString();
@@ -187,9 +191,9 @@ function bixal_uswds_preprocess_paragraph(&$vars) {
           // If a height and width is set, update the height so it's the same
           // scale as the new width.
           if (!empty($image_field_value['height']) && !empty($image_field_value['width'])) {
-            $image_field_render_array[0]['#item_attributes']['height'] = floor($image_field_value['height'] * ($width / $image_field_value['width']));
+            $image_field_render_array[0]['#attributes']['height'] = floor($image_field_value['height'] * ($width / $image_field_value['width']));
           }
-          $image_field_render_array[0]['#item_attributes']['width'] = $width;
+          $image_field_render_array[0]['#attributes']['width'] = $width;
         }
         $url_field = $paragraph->get('field_url');
         if (!$url_field->isEmpty()) {


### PR DESCRIPTION
<!--
  **PR title**

  **Feature PR's**
  - BSD fixes #ISSUE_NO: Brief description
  - BSD-ISSUE_NO: Brief description

  **Releases**
  Release/RELEASE_NO
-->

# Summary

The images on dev and stage look all messed up in the accrediation

dev 
<img width="412" height="158" alt="image" src="https://github.com/user-attachments/assets/69a0601d-1e47-4b23-9aef-f1c3c4ee4290" />
stage
<img width="447" height="328" alt="image" src="https://github.com/user-attachments/assets/d92d5d83-e979-4934-b6b2-8149c2a4e7c6" />



## Related issue

Closes #581

<!--
  Every pull request should have a related issue.
  If one doesn't exist, create one here:
  https://github.com/Bixal/bixal-site-drupal/issues/new/choose
-->

## Solution

The #item_attributes array was deprecated, use #attributes instead.

<img width="346" height="160" alt="image" src="https://github.com/user-attachments/assets/ebc4a9de-089f-4866-bcba-d5c00263ddb7" />


## Testing and review

Visit the footer on any non-admin page and check out the accrediation images.

<!--
## Dependencies

Dependency updates (if any, uncomment this section).

| Dependency                   | Old      | New     |
| :--------------------------- | :------- | :------ |
| [Updated dependency example] | [1.0.0]  | [1.0.1] |
| [New dependency example]     | --       | [3.0.1] |
| [Removed dependency example] | [2.10.2] | --      |
-->
