### PR TITLE
BSD fixes #586 Update field group to 4x

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -63,7 +63,7 @@
         "drupal/edit_media_modal": "^2.0",
         "drupal/editoria11y": "^2.2",
         "drupal/email_username": "^1.0",
-        "drupal/field_group": "^3.4",
+        "drupal/field_group": "^4.0",
         "drupal/file_resup": "^2.0",
         "drupal/google_tag": "^2.0",
         "drupal/imagecache_external": "^3.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "7908dc66ba32ffe457613d8e2b15ba6f",
+    "content-hash": "ef6dfd31a55c3d16772019cb6c99860a",
     "packages": [
         {
             "name": "asm89/stack-cors",
@@ -3181,20 +3181,20 @@
         },
         {
             "name": "drupal/field_group",
-            "version": "3.6.0",
+            "version": "4.0.0",
             "source": {
                 "type": "git",
                 "url": "https://git.drupalcode.org/project/field_group.git",
-                "reference": "8.x-3.6"
+                "reference": "4.0.0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://ftp.drupal.org/files/projects/field_group-8.x-3.6.zip",
-                "reference": "8.x-3.6",
-                "shasum": "427c0a65dc1936e69e60c120776056cfe5b43e86"
+                "url": "https://ftp.drupal.org/files/projects/field_group-4.0.0.zip",
+                "reference": "4.0.0",
+                "shasum": "d3ff81d8a64b6ac392989b668cfa417be5101642"
             },
             "require": {
-                "drupal/core": "^9.2 || ^10 || ^11"
+                "drupal/core": "^10.3 || ^11"
             },
             "require-dev": {
                 "drupal/jquery_ui_accordion": "*"
@@ -3202,8 +3202,8 @@
             "type": "drupal-module",
             "extra": {
                 "drupal": {
-                    "version": "8.x-3.6",
-                    "datestamp": "1722672510",
+                    "version": "4.0.0",
+                    "datestamp": "1745478894",
                     "security-coverage": {
                         "status": "covered",
                         "message": "Covered by Drupal's security advisory policy"

--- a/composer.log
+++ b/composer.log
@@ -99,3 +99,4 @@ aac650de6caa9551ceb34586438545ec|Matt Poole|feature/BSD-578-update-deps|Wed Jun 
 a0219d71ff5b571ca8d0446c3ba03a68|Matt Poole|feature/BSD-578-update-deps|Thu Jul  9 09:36:21 EDT 2026|./composer.sh update -w
 ef94fc8052557559e673950e0f8c29fe|Matt Poole|feature/BSD-583-update-deps|Wed Jul 29 16:03:58 EDT 2026|./composer.sh update drupal/core-* -W
 f3b6dba8f19469b27e7b84f5191f1850|Matt Poole|feature/BSD-583-update-deps|Wed Jul 29 16:04:16 EDT 2026|./composer.sh update -w
+4b4bc1e8f07529fe1bd07390eeae1c08|Matt Poole|feature/BSD-586-field-group-4x|Wed Aug  5 16:42:01 EDT 2026|./composer.sh require drupal/field_group:^4.0

--- a/config/sync/admin_toolbar.settings.yml
+++ b/config/sync/admin_toolbar.settings.yml
@@ -1,7 +1,7 @@
 _core:
   default_config_hash: jvTSppzcgH5wnzBhX5xnAExcp2I1CzkQ_aky65XNfYI
+enable_toggle_shortcut: false
 menu_depth: 4
 hoverintent_behavior:
   enabled: true
   timeout: 500
-enable_toggle_shortcut: false

--- a/config/sync/imagecache_external.settings.yml
+++ b/config/sync/imagecache_external.settings.yml
@@ -23,7 +23,7 @@ imagecache_external_allowed_mimetypes:
   - application/octet-stream;charset=utf-8
   - binary/octet-stream
 imagecache_external_cron_flush_frequency: 0
+imagecache_external_cron_flush_originals: true
 svg_settings:
   allowed_tags: {  }
   allowed_attributes: {  }
-imagecache_external_cron_flush_originals: true

--- a/config/sync/override_node_options.settings.yml
+++ b/config/sync/override_node_options.settings.yml
@@ -1,4 +1,4 @@
 _core:
   default_config_hash: Y0Jxf-pLD0BpNVMs5eY2YL6Ctcxc-sKfAi5IJa_bwQk
-general_permissions: 1
-specific_permissions: 0
+general_permissions: true
+specific_permissions: false

--- a/config/sync/seckit.settings.yml
+++ b/config/sync/seckit.settings.yml
@@ -21,11 +21,11 @@ seckit_xss:
     upgrade-req: false
     policy-uri: ''
   x_xss:
+    select: 0
     seckit_x_xss_option_disable: Disabled
     seckit_x_xss_option_0: '0'
     seckit_x_xss_option_1: 1;
     seckit_x_xss_option_1_block: '1; mode=block'
-    select: 0
 seckit_csrf:
   origin: false
   origin_whitelist: ''


### PR DESCRIPTION
# Summary

Field group was a major version behind. This bumps it.
There were no breaking changes in the 4.0 version https://www.drupal.org/project/field_group/releases/4.0.0


## Related issue

Closes #586 

<!--
  Every pull request should have a related issue.
  If one doesn't exist, create one here:
  https://github.com/Bixal/bixal-site-drupal/issues/new/choose
-->

## Solution

Update field_group to 4.0 version.

## Testing and review

When you edit a landing page, you should see the tabs for the hero and main content.
Inside of main content, if you have a section, you should see tabs of content and display settings.

<img width="590" height="336" alt="image" src="https://github.com/user-attachments/assets/1a1ea093-482c-44fc-b412-a7c9c91502c7" />

<!--
How to test this work.

1. Describe the tests that you ran to verify your changes
2. Provide instructions to reproduce
3. Clarify the type of feedback you are looking for
-->

<!--
## Dependencies

Dependency updates (if any, uncomment this section).

| Dependency                   | Old      | New     |
| :--------------------------- | :------- | :------ |
| [Updated dependency example] | [1.0.0]  | [1.0.1] |
| [New dependency example]     | --       | [3.0.1] |
| [Removed dependency example] | [2.10.2] | --      |
-->
